### PR TITLE
APM-1632: Add Bintray deployment (and other devops changes)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
                 name: Test deployment to Bintray
                 command: |
                   set -ou pipefail
-                  ./gradlew bintrayUpload
+                  bash .devops/deploy.sh beta
 
             ##
             # SAVE CACHES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,6 @@ jobs:
                   if [[ ! -f ~/.localCircleBuild ]]; then
                     TERM=dumb ./gradlew updatewhitesource
                   fi
-            - run:
-                name: Test deployment to Bintray
-                command: |
-                  set -ou pipefail
-                  bash .devops/deploy.sh beta
 
             ##
             # SAVE CACHES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
                   if [[ "$CIRCLE_BUILD_NUM" == '' ]]; then
                     touch ~/.localCircleBuild
                   fi
-                  if [[ "$CIRCLE_PR_USERNAME" != '' ]]; then
+                  if [[ "$CIRCLE_PR_USERNAME" != '' || "$CIRCLE_PULL_REQUEST" != '' ]]; then
                     touch ~/.prCircleBuild
                   fi
             - add_ssh_keys
@@ -61,7 +61,7 @@ jobs:
             - run:
                 name: Run Whitesource
                 command: |
-                  if [[ ! -f ~/.localCircleBuild ]]; then
+                  if [[ ! -f ~/.localCircleBuild && ! -f ~/.prCircleBuild ]]; then
                     TERM=dumb ./gradlew updatewhitesource
                   fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,14 +33,38 @@ jobs:
                 command: |
                   bash .devops/calculate-app-version.sh
                   cp ~/.version VERSION
+            - run:
+                name: Prep for Whitesource
+                command: |
+                  if [[ ! -f ~/.localCircleBuild ]]; then
+                    bash .devops/prep-for-whitesource.sh
+                  fi
 
             ##
             # RESTORE CACHES
             ##
+            - restore_cache:
+                key: v1-dependency-cache-{{ checksum "build.gradle" }}
+            - restore_cache:
+                key: v1-wrapper-cache-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
             ##
-            # TESTS
+            # GRADLE
             ##
+            - run:
+                name: Install Gradle dependencies
+                command: |
+                  TERM=dumb ./gradlew dependencies
+            - run:
+                name: Run Gradle Tests
+                command: |
+                  TERM=dumb ./gradlew clean test --info
+            - run:
+                name: Run Whitesource
+                command: |
+                  if [[ ! -f ~/.localCircleBuild ]]; then
+                    TERM=dumb ./gradlew updatewhitesource
+                  fi
             - run:
                 name: Test deployment to Bintray
                 command: |
@@ -50,6 +74,14 @@ jobs:
             ##
             # SAVE CACHES
             ##
+            - save_cache:
+                key: v1-dependency-cache-{{ checksum "build.gradle" }}
+                paths:
+                    - /home/circleci/.gradle/caches
+            - save_cache:
+                key: v1-wrapper-cache-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+                paths:
+                    - /home/circleci/.gradle/wrapper
 
             ##
             # DEPLOYMENT

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
             TZ: "/usr/share/zoneinfo/America/Detroit"
         working_directory: ~/app
         docker:
-            - image: circleci/node:9-stretch
+            - image: circleci/openjdk:8u181-jdk-stretch-node-browsers
         steps:
 
             ##
@@ -41,6 +41,11 @@ jobs:
             ##
             # TESTS
             ##
+            - run:
+                name: Test deployment to Bintray
+                command: |
+                  set -ou pipefail
+                  ./gradlew bintrayUpload
 
             ##
             # SAVE CACHES

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
                 name: Calculate codebase version
                 command: |
                   bash .devops/calculate-app-version.sh
-                  cp ~/.version VERSION
             - run:
                 name: Prep for Whitesource
                 command: |

--- a/.devops/deploy.sh
+++ b/.devops/deploy.sh
@@ -5,8 +5,8 @@ if [[ "$1" == "" ]]; then
   exit 1
 fi
 ENVDIR=$1
-VERSION="$(cat VERSION)"
-VERSION_SIMPLE=$(cat VERSION | xargs | cut -f1 -d"+")
+VERSION="$(cat ~/.version)"
+VERSION_SIMPLE=$(cat ~/.version | xargs | cut -f1 -d"+")
 export TIMESTAMP="$(date --rfc-3339=seconds | sed 's/ /T/')"
 
 sed -i -e "s/theVersion=.*/theVersion=$VERSION_SIMPLE/" gradle.properties

--- a/.devops/deploy.sh
+++ b/.devops/deploy.sh
@@ -9,4 +9,5 @@ VERSION="$(cat VERSION)"
 VERSION_SIMPLE=$(cat VERSION | xargs | cut -f1 -d"+")
 export TIMESTAMP="$(date --rfc-3339=seconds | sed 's/ /T/')"
 
+sed -i -e "s/theVersion=.*/theVersion=$VERSION_SIMPLE/" gradle.properties
 gradle bintrayUpload

--- a/.devops/deploy.sh
+++ b/.devops/deploy.sh
@@ -8,3 +8,5 @@ ENVDIR=$1
 VERSION="$(cat VERSION)"
 VERSION_SIMPLE=$(cat VERSION | xargs | cut -f1 -d"+")
 export TIMESTAMP="$(date --rfc-3339=seconds | sed 's/ /T/')"
+
+gradle bintrayUpload

--- a/.devops/prep-for-whitesource.sh
+++ b/.devops/prep-for-whitesource.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+# When running CircleCI locally, don't do anything.
+if [[ "$CIRCLE_BUILD_NUM" != '' && "$CIRCLE_BRANCH" != 'HEAD' ]]; then
+  # Get the product name from the product token.
+  API_REQ="{\"requestType\":\"getOrganizationProductVitals\",\"orgToken\":\"$WHITESOURCE_ORG_TOKEN\"}"
+  PRODUCT_NAME=$(curl -H "Content-Type: application/json" -H "charset: UTF-8" https://saas.whitesourcesoftware.com/api -d $API_REQ | jq -r '.productVitals[].name')
+  # Augment the build script to use WhiteSource.
+  echo >> build.gradle
+  cat >>build.gradle <<EOF
+whitesource {
+    orgToken '${WHITESOURCE_ORG_TOKEN}'
+    productName '${PRODUCT_NAME}'
+    dependencyFilter includeAllDependencies
+    includeConfiguration configurations.runtime
+    includeConfiguration configurations.compile
+    includeConfiguration configurations.testCompile
+}
+EOF
+else
+  echo 'This is a local CircleCI build; skipping WhiteSource.'
+fi

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,6 @@ bintray {
     user = System.getenv('BINTRAY_USER')
     key = System.getenv('BINTRAY_API_KEY')
     publications = ['AukletJavaAgent']
-    dryRun = true
     pkg {
         userOrg = 'aukletio'
         repo = 'agent-java'

--- a/build.gradle
+++ b/build.gradle
@@ -69,13 +69,6 @@ def pomConfig = {
             distribution "repo"
         }
     }
-    developers {
-        developer {
-            id "aukletio"
-            name "auklet.io"
-            email "hello@auklet.io"
-        }
-    }
     scm {
        url "https://github.com/aukletio/Auklet-Agent-Java"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,11 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 jar {
     manifest {
         attributes(
-                'Built-By': 'CircleCI',
-                'Built-Date': new Date(),
-                'Built-JDK': System.getProperty('java.version'),
-                'Implementation-Version': version,
-                'Implementation-Title': project.name,
+            'Built-By': 'CircleCI',
+            'Built-Date': new Date(),
+            'Built-JDK': System.getProperty('java.version'),
+            'Implementation-Version': version,
+            'Implementation-Title': project.name,
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ bintray {
     publications = ['AukletJavaAgent']
     dryRun = true
     pkg {
+        userOrg = 'aukletio'
         repo = 'agent-java'
         name = "${theName}"
         desc = "${description}"

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,16 @@ test {
     testLogging.showStandardStreams = true
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 jar {
     manifest {
         attributes(

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'whitesource'
 
 group "${theGroup}"
 version "${theVersion}"
+description = 'Official Auklet SDK for Java and other JVM languages.'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
@@ -91,7 +92,7 @@ publishing {
             version "${theVersion}"
             pom.withXml {
                 def root = asNode()
-                root.appendNode('description', 'Official Auklet SDK for Java and other JVM languages.')
+                root.appendNode('description', "${description}")
                 root.appendNode('name', 'Auklet Java Agent')
                 root.appendNode('url', 'https://auklet.io')
                 root.children().last() + pomConfig
@@ -105,4 +106,14 @@ bintray {
     key = System.getenv('BINTRAY_API_KEY')
     publications = ['AukletJavaAgent']
     dryRun = true
+    pkg {
+        repo = 'agent-java'
+        name = "${theName}"
+        desc = "${description}"
+        websiteUrl = 'https://github.com/aukletio/Auklet-Agent-Java'
+        issueTrackerUrl = 'https://github.com/aukletio/Auklet-Agent-Java/issues'
+        vcsUrl = 'https://github.com/aukletio/Auklet-Agent-Java.git'
+        licenses = ['Apache-2.0']
+        publicDownloadNumbers = true
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -104,4 +104,5 @@ bintray {
     user = System.getenv('BINTRAY_USER')
     key = System.getenv('BINTRAY_API_KEY')
     publications = ['AukletJavaAgent']
+    dryRun = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,32 @@
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath group: 'org.whitesource', name: 'whitesource-gradle-plugin', version: '0.8'
     }
 }
-plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.1'
-    id 'java'
-}
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow' version '2.0.1'
+    id 'maven'
+    id 'maven-publish'
+    id 'com.jfrog.bintray' version '1.8.4'
+}
 
 apply plugin: 'whitesource'
 
 group "${theGroup}"
 version "${theVersion}"
 
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
 repositories {
-    mavenCentral()
+    jcenter()
 }
+
 dependencies {
     compile "org.apache.httpcomponents:httpclient:4.5.5"
     compile "com.googlecode.json-simple:json-simple:1.1.1"
@@ -43,4 +48,50 @@ jar {
                 'Implementation-Title': project.name,
         )
     }
+}
+
+def pomConfig = {
+    licenses {
+        license {
+            name "The Apache Software License, Version 2.0"
+            url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            distribution "repo"
+        }
+    }
+    developers {
+        developer {
+            id "aukletio"
+            name "auklet.io"
+            email "hello@auklet.io"
+        }
+    }
+    scm {
+       url "https://github.com/aukletio/Auklet-Agent-Java"
+    }
+}
+
+publishing {
+    publications {
+        AukletJavaAgent(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            groupId "${theGroup}"
+            artifactId "${theName}"
+            version "${theVersion}"
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'Official Auklet SDK for Java and other JVM languages.')
+                root.appendNode('name', 'Auklet Java Agent')
+                root.appendNode('url', 'https://auklet.io')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+    publications = ['AukletJavaAgent']
 }

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,7 @@ bintray {
     user = System.getenv('BINTRAY_USER')
     key = System.getenv('BINTRAY_API_KEY')
     publications = ['AukletJavaAgent']
+    publish = true
     pkg {
         userOrg = 'aukletio'
         repo = 'agent-java'

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -12,7 +12,6 @@ public final class Auklet {
 
     static protected String AppId;
     static protected String ApiKey;
-    static protected String baseUrl = "https://api-staging.auklet.io/";
     static protected MqttClient client;
 
     /*
@@ -91,6 +90,11 @@ public final class Auklet {
             } catch (InterruptedException e2) {
             }
         }
+    }
+
+    public static String getBaseUrl() {
+      String fromEnv = System.getenv('AUKLET_BASEURL');
+      return fromEnv != null ? fromEnv : "https://api.auklet.io";
     }
 
 }

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -93,7 +93,7 @@ public final class Auklet {
     }
 
     public static String getBaseUrl() {
-      String fromEnv = System.getenv('AUKLET_BASEURL');
+      String fromEnv = System.getenv("AUKLET_BASEURL");
       return fromEnv != null ? fromEnv : "https://api.auklet.io";
     }
 

--- a/src/main/java/io/auklet/agent/Device.java
+++ b/src/main/java/io/auklet/agent/Device.java
@@ -55,7 +55,7 @@ public final class Device {
             JSONObject obj = new JSONObject();
             obj.put("mac_address_hash", Util.getMacAddressHash());
             obj.put("application", Auklet.AppId);
-            HttpPost request = new HttpPost(Auklet.baseUrl + "/private/devices/");
+            HttpPost request = new HttpPost(Auklet.getBaseUrl() + "/private/devices/");
             StringEntity params = new StringEntity(obj.toJSONString());
             request.addHeader("content-type", "application/json");
             request.addHeader("Authorization", "JWT "+Auklet.ApiKey);
@@ -135,7 +135,7 @@ public final class Device {
 
         try {
             HttpClient httpClient = HttpClientBuilder.create().build();
-            URL newUrl = new URL(Auklet.baseUrl + "private/devices/certificates/");
+            URL newUrl = new URL(Auklet.getBaseUrl() + "/private/devices/certificates/");
             HttpURLConnection con = (HttpURLConnection) newUrl.openConnection();
 
             con.setRequestProperty("Authorization", "JWT " + Auklet.ApiKey);;

--- a/src/main/java/io/auklet/agent/MQTT.java
+++ b/src/main/java/io/auklet/agent/MQTT.java
@@ -110,7 +110,7 @@ public final class MQTT {
 
         try {
             JSONObject obj = new JSONObject();
-            HttpGet request = new HttpGet(Auklet.baseUrl + "private/devices/config/");
+            HttpGet request = new HttpGet(Auklet.getBaseUrl() + "/private/devices/config/");
             request.addHeader("content-type", "application/json");
             request.addHeader("Authorization", "JWT " + Auklet.ApiKey);
             HttpResponse response = httpClient.execute(request);


### PR DESCRIPTION
- All pushes to the 3 main branches will result in published artifacts being pushed to Bintray.
- Added WhiteSource scanning (skipped for PR builds).
- Parameterized the Auklet base URL via the env var `AUKLET_BASEURL`.
- Added CircleCI dependency caching.
- Added Apache 2.0 license.