### PR TITLE
Add duplicate build check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
             ##
             # SETUP
             ##
+            - add_ssh_keys
+            - checkout
             - run:
                 name: Flag local/PR builds
                 command: |
@@ -27,8 +29,6 @@ jobs:
                 key: build-status-{{ .Revision }}
                 paths:
                     - /home/circleci/.activeBuild
-            - add_ssh_keys
-            - checkout
             - run:
                 name: Install jq
                 command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2
 jobs:
     build:
         environment:
+            ACTIVE_BUILD_FILE: "/home/circleci/.activeBuild"
             TZ: "/usr/share/zoneinfo/America/Detroit"
         working_directory: ~/app
         docker:
@@ -15,12 +16,17 @@ jobs:
             - run:
                 name: Flag local/PR builds
                 command: |
-                  if [[ "$CIRCLE_BUILD_NUM" == '' ]]; then
-                    touch ~/.localCircleBuild
-                  fi
-                  if [[ "$CIRCLE_PR_USERNAME" != '' || "$CIRCLE_PULL_REQUEST" != '' ]]; then
-                    touch ~/.prCircleBuild
-                  fi
+                  bash .devops/flagBuilds.sh
+            - restore_cache:
+                key: build-status-{{ .Revision }}
+            - run:
+                name: Duplicate build check
+                command: |
+                  bash .devops/duplicateBuildCheck.sh
+            - save_cache:
+                key: build-status-{{ .Revision }}
+                paths:
+                    - /home/circleci/.activeBuild
             - add_ssh_keys
             - checkout
             - run:
@@ -80,6 +86,12 @@ jobs:
             ##
             # DEPLOYMENT
             ##
+            - restore_cache:
+                key: build-status-{{ .Revision }}
+            - run:
+                name: Duplicate build check
+                command: |
+                  bash .devops/duplicateBuildCheck.sh
             - run:
                 name: Deploy Beta (master)
                 command: |

--- a/.devops/duplicateBuildCheck.sh
+++ b/.devops/duplicateBuildCheck.sh
@@ -4,11 +4,15 @@ if [[ ! -f ~/.localCircleBuild && ! -f ~/.prCircleBuild ]]; then
   touch $ACTIVE_BUILD_FILE
   ACTIVE_BUILD_NUM=$(cat $ACTIVE_BUILD_FILE)
   if [[ "$ACTIVE_BUILD_NUM" == '' ]]; then
+    echo 'This is the first build for this VCS revision.'
     echo $CIRCLE_BUILD_NUM > $ACTIVE_BUILD_FILE
   elif (( $CIRCLE_BUILD_NUM < $ACTIVE_BUILD_NUM )); then
     echo 'WARNING: there is a newer CircleCI build for this commit hash. This build will now abort.'
     exit 1
   else
+    echo 'This is the newest build for this VCS revision.'
     echo $CIRCLE_BUILD_NUM > $ACTIVE_BUILD_FILE
   fi
+else
+  echo 'This is a local/PR CircleCI build; skipping duplicate build check.'
 fi

--- a/.devops/duplicateBuildCheck.sh
+++ b/.devops/duplicateBuildCheck.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+if [[ ! -f ~/.localCircleBuild && ! -f ~/.prCircleBuild ]]; then
+  touch $ACTIVE_BUILD_FILE
+  ACTIVE_BUILD_NUM=$(cat $ACTIVE_BUILD_FILE)
+  if [[ "$ACTIVE_BUILD_NUM" == '' ]]; then
+    echo $CIRCLE_BUILD_NUM > $ACTIVE_BUILD_FILE
+  elif (( $CIRCLE_BUILD_NUM < $ACTIVE_BUILD_NUM )); then
+    echo 'WARNING: there is a newer CircleCI build for this commit hash. This build will now abort.'
+    exit 1
+  else
+    echo $CIRCLE_BUILD_NUM > $ACTIVE_BUILD_FILE
+  fi
+fi

--- a/.devops/flagBuilds.sh
+++ b/.devops/flagBuilds.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+if [[ "$CIRCLE_BUILD_NUM" == '' ]]; then
+  touch ~/.localCircleBuild
+elif [[ "$CIRCLE_PR_NUMBER" != '' ]]; then
+  touch ~/.prCircleBuild
+elif [[ "$CIRCLE_BRANCH" != 'master' && "$CIRCLE_BRANCH" != 'rc' && "$CIRCLE_BRANCH" != 'release' ]]; then
+  touch ~/.prCircleBuild
+fi

--- a/.devops/flagBuilds.sh
+++ b/.devops/flagBuilds.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 if [[ "$CIRCLE_BUILD_NUM" == '' ]]; then
+  echo 'This is a local build.'
   touch ~/.localCircleBuild
 elif [[ "$CIRCLE_PR_NUMBER" != '' ]]; then
+  echo 'This is a PR build.'
   touch ~/.prCircleBuild
 elif [[ "$CIRCLE_BRANCH" != 'master' && "$CIRCLE_BRANCH" != 'rc' && "$CIRCLE_BRANCH" != 'release' ]]; then
+  echo 'This is a PR build.'
   touch ~/.prCircleBuild
 fi
+echo 'This is a main branch build.'

--- a/.devops/flagBuilds.sh
+++ b/.devops/flagBuilds.sh
@@ -9,5 +9,6 @@ elif [[ "$CIRCLE_PR_NUMBER" != '' ]]; then
 elif [[ "$CIRCLE_BRANCH" != 'master' && "$CIRCLE_BRANCH" != 'rc' && "$CIRCLE_BRANCH" != 'release' ]]; then
   echo 'This is a PR build.'
   touch ~/.prCircleBuild
+else
+  echo 'This is a main branch build.'
 fi
-echo 'This is a main branch build.'

--- a/.devops/prep-for-whitesource.sh
+++ b/.devops/prep-for-whitesource.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 # When running CircleCI locally, don't do anything.
-if [[ "$CIRCLE_BUILD_NUM" != '' && "$CIRCLE_BRANCH" != 'HEAD' ]]; then
+if [[ ! -f ~/.localCircleBuild && ! -f ~/.prCircleBuild ]]; then
   # Get the product name from the product token.
   API_REQ="{\"requestType\":\"getOrganizationProductVitals\",\"orgToken\":\"$WHITESOURCE_ORG_TOKEN\"}"
   PRODUCT_NAME=$(curl -H "Content-Type: application/json" -H "charset: UTF-8" https://saas.whitesourcesoftware.com/api -d $API_REQ | jq -r '.productVitals[].name')
@@ -18,5 +18,5 @@ whitesource {
 }
 EOF
 else
-  echo 'This is a local CircleCI build; skipping WhiteSource.'
+  echo 'This is a local/PR CircleCI build; skipping WhiteSource.'
 fi


### PR DESCRIPTION
CircleCI is now building `origin` branch pushes twice - once for being an `origin` branch and again for being the `HEAD` of an open PR. This should only happen in theory to the `master` branch because it is the default branch, but I've already seen it happen with the `rc` branch.

Aside from the above-mentioned `rc` double-build issue, which I believe is a bug, this behavior is by design and it messes with our deploy processes. This PR fixes this by checking for/aborting redundant builds.