### PR TITLE
Add more error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Auklet for Java
 
-This is the official Java agent for Auklet. It officially supports Java 9+.
+This is the official Java agent for Auklet. It officially supports Java 8+.
 It is currently tested on Oracle java Hotspot JVM. We plan on doing more 
 testing on other currently active JVMs.
 
@@ -21,7 +21,7 @@ import io.auklet.agent.Auklet;
 public class demo {
    
    public static void main(String []arg) {
-       Auklet.init(<App_Id>, <Api_key>);
+       Auklet.init("<App_Id>", "<Api_key>");
        ...
    }
 }
@@ -31,7 +31,7 @@ public class demo {
 public class Demo {
    
    public static void main(String []arg) {
-       Auklet.init(<App_Id>, <Api_key>, false);
+       Auklet.init("<App_Id>", "<Api_key>", false);
        ...
        Auklet.shutdown()
    }

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -56,10 +56,13 @@ public final class Auklet {
             folderPath = Util.createCustomFolder("java.io.tmpdir");
         }
         System.out.println("Directory to store creds: " + folderPath);
-        Device.get_Certs(folderPath);
-        Device.register_device(folderPath);
-        client = MQTT.connectMqtt(folderPath, mqttThreadPool);
-        AukletExceptionHandler.setup();
+
+        if(Device.get_Certs(folderPath) && Device.register_device(folderPath)) {
+            client = MQTT.connectMqtt(folderPath, mqttThreadPool);
+            if (client != null) {
+                AukletExceptionHandler.setup();
+            }
+        }
     }
 
     public static void init(String appId, String apiKey){

--- a/src/main/java/io/auklet/agent/AukletExceptionHandler.java
+++ b/src/main/java/io/auklet/agent/AukletExceptionHandler.java
@@ -27,8 +27,6 @@ public final class AukletExceptionHandler implements Thread.UncaughtExceptionHan
 
         else if (!(thrown instanceof ThreadDeath)) {
             List<Object> list = new ArrayList<>();
-            //MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
-            // CHECKSTYLE.OFF: RegexpSinglelineJava
             System.err.print("Exception in thread \"" + thread.getName() + "\" ");
             thrown.printStackTrace(System.err);
 

--- a/src/main/java/io/auklet/agent/Device.java
+++ b/src/main/java/io/auklet/agent/Device.java
@@ -83,6 +83,9 @@ public final class Device {
                 String text = null;
                 try (Scanner scanner = new Scanner(response.getEntity().getContent(), StandardCharsets.UTF_8.name())) {
                     text = scanner.useDelimiter("\\A").next();
+                } catch (Exception e) {
+                    System.out.println("Exception during reading contents of create device: " + e.getMessage());
+                    return null;
                 }
                 JSONParser parser = new JSONParser();
                 JSONObject myResponse = (JSONObject) parser.parse(text);

--- a/src/main/java/io/auklet/agent/MQTT.java
+++ b/src/main/java/io/auklet/agent/MQTT.java
@@ -29,40 +29,42 @@ public final class MQTT {
 
         JSONObject brokerJSON = getbroker();
 
-        String serverUrl = "ssl://" + brokerJSON.get("brokers") + ":" + brokerJSON.get("port");
-        String caFilePath = folderPath + "/CA";
-        String mqttUserName = Device.getClient_Username();
-        String mqttPassword = Device.getClient_Password();
+        if(brokerJSON != null) {
+            String serverUrl = "ssl://" + brokerJSON.get("brokers") + ":" + brokerJSON.get("port");
+            String caFilePath = folderPath + "/CA";
+            String mqttUserName = Device.getClient_Username();
+            String mqttPassword = Device.getClient_Password();
 
-        MqttClient client;
-        try {
-            client = new MqttClient(serverUrl, Device.getClient_Id(), new MemoryPersistence(), executorService);
-            MqttConnectOptions options = new MqttConnectOptions();
-            options.setUserName(mqttUserName);
-            options.setPassword(mqttPassword.toCharArray());
+            MqttClient client;
+            try {
+                client = new MqttClient(serverUrl, Device.getClient_Id(), new MemoryPersistence(), executorService);
+                MqttConnectOptions options = new MqttConnectOptions();
+                options.setUserName(mqttUserName);
+                options.setPassword(mqttPassword.toCharArray());
 
-            options.setConnectionTimeout(60);
-            options.setKeepAliveInterval(60);
-            options.setCleanSession(true);
-            options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);
-
-
-            SSLSocketFactory socketFactory = getSocketFactory(caFilePath);
-            options.setSocketFactory(socketFactory);
-
-            System.out.println("starting connect the server...");
-            client.connect(options);
-            System.out.println("connected!");
-
-            return client;
+                options.setConnectionTimeout(60);
+                options.setKeepAliveInterval(60);
+                options.setCleanSession(true);
+                options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);
 
 
-        } catch (MqttException e) {
-            e.printStackTrace();
-            System.out.println(e.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-            System.out.println(e.getMessage());
+                SSLSocketFactory socketFactory = getSocketFactory(caFilePath);
+                options.setSocketFactory(socketFactory);
+
+                System.out.println("starting connect the server...");
+                client.connect(options);
+                System.out.println("connected!");
+
+                return client;
+
+
+            } catch (MqttException e) {
+                e.printStackTrace();
+                System.out.println(e.getMessage());
+            } catch (Exception e) {
+                e.printStackTrace();
+                System.out.println(e.getMessage());
+            }
         }
 
         return null;
@@ -115,14 +117,19 @@ public final class MQTT {
             request.addHeader("Authorization", "JWT " + Auklet.ApiKey);
             HttpResponse response = httpClient.execute(request);
 
-            String text = null;
-            try (Scanner scanner = new Scanner(response.getEntity().getContent(), StandardCharsets.UTF_8.name())) {
-                text = scanner.useDelimiter("\\A").next();
-            }
+            if (response.getStatusLine().getStatusCode() == 200) {
+                String text = null;
+                try (Scanner scanner = new Scanner(response.getEntity().getContent(), StandardCharsets.UTF_8.name())) {
+                    text = scanner.useDelimiter("\\A").next();
+                }
 
-            JSONParser parser = new JSONParser();
-            JSONObject brokers = (JSONObject) parser.parse(text);
-            return brokers;
+                JSONParser parser = new JSONParser();
+                JSONObject brokers = (JSONObject) parser.parse(text);
+                return brokers;
+            }
+            else {
+                System.out.println("Get broker response code: " + response.getStatusLine().getStatusCode());
+            }
 
         }catch(Exception e) {
             e.printStackTrace();

--- a/src/main/java/io/auklet/agent/MQTT.java
+++ b/src/main/java/io/auklet/agent/MQTT.java
@@ -121,8 +121,10 @@ public final class MQTT {
                 String text = null;
                 try (Scanner scanner = new Scanner(response.getEntity().getContent(), StandardCharsets.UTF_8.name())) {
                     text = scanner.useDelimiter("\\A").next();
+                } catch (Exception e) {
+                    System.out.println("Exception occurred during reading brokers info: " + e.getMessage());
+                    return null;
                 }
-
                 JSONParser parser = new JSONParser();
                 JSONObject brokers = (JSONObject) parser.parse(text);
                 return brokers;

--- a/src/main/java/io/auklet/agent/Util.java
+++ b/src/main/java/io/auklet/agent/Util.java
@@ -59,7 +59,6 @@ public final class Util {
                     whatismyip.openStream()));
 
             ipAddr = in.readLine(); //you get the IP as a String
-            System.out.println("Current IP Address: " + ipAddr);
 
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
This PR tries to add more robust error handling in java agent. 
If any of the following fails we do not set the unhandled exception handler 
    - We can't get the CA cert 
    - Can't register a device
    - Could not connect to MQTT client 