### PR TITLE
send the complete exception message

### DIFF
--- a/src/main/java/io/auklet/agent/AukletExceptionHandler.java
+++ b/src/main/java/io/auklet/agent/AukletExceptionHandler.java
@@ -57,7 +57,7 @@ public final class AukletExceptionHandler implements Thread.UncaughtExceptionHan
             map.put("lineNumber", se.getLineNumber());
             list.add(map);
         }
-        setStackTrace(list, thrown.getMessage());
+        setStackTrace(list, thrown.toString());
 
         try {
             byte[] bytesToSend = Messages.createMessagePack();


### PR DESCRIPTION
This PR fixes the issue of not getting meaningful exception messages on the front-end. Rather we now send an entire exception as a string. 