### PR TITLE
support for an arbitrary dir for config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ public class Demo {
 // where you think the program might exit or inside your own shutdown hook.
 ```
 
-* The agent needs a dedicated folder to create and stores the configuration files on the local machine. 
-Upon every restart the agent tries to create configuration files if they don't already exist. 
-* If the user wants Auklet agent to use specific folder then it can be done using the following command: 
-`java -Dauklet.config.dir="custom/file/path/dir" MyApp`
-* If the `auklet.config.dir` sysProperty is not defined then the agent chooses the directory in the following order
-of its accessibility: working directory -> home directory -> temp directory
+* The agent needs a dedicated folder to create and store its configuration files. The agent will create these files 
+on startup if they do not exist, or will use files that are already available on disk.
+* By default, the agent will use the following JVM system properties, in order, to determine the location from which 
+to read/write its configuration files: `user.dir`, `user.home`, `java.io.tmpdir`. 
+The agent will use the first one of these locations that is writable.
+* If you need to use a specific location for the agent's configuration files other than what is listed above, you can 
+set the JVM system property `auklet.config.dir` or use env variable `AUKLET_CONFIG_DIR` and the agent will attempt to 
+use that value first, assuming it is writable. 
+If it is set to a non-writable directory, or if the property is not set, the agent will fallback to the 
+other properties described above.
 
 # Authorization
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ public class Demo {
 // reconnecting in the future. It is important that you call `Auklet.shutdown()`
 // where you think the program might exit or inside your own shutdown hook.
 ```
+
+* The agent needs a dedicated folder to create and stores the configuration files on the local machine. 
+Upon every restart the agent tries to create configuration files if they don't already exist. 
+* If the user wants Auklet agent to use specific folder then it can be done using the following command: 
+`java -Dauklet.config.dir="custom/file/path/dir" MyApp`
+* If the `auklet.config.dir` sysProperty is not defined then the agent chooses the directory in the following order
+of its accessibility: working directory -> home directory -> temp directory
+
 # Authorization
 
 To authorize your application you need to provide both an API key and app ID.

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -59,7 +59,10 @@ public final class Auklet {
     }
 
     private static void createFolderPath() {
-        folderPath = Util.createCustomFolder("auklet.config.dir");
+        folderPath = Util.createCustomFolder(System.getenv("AUKLET_CONFIG_DIR"));
+        if (folderPath == null) {
+            folderPath = Util.createCustomFolder("auklet.config.dir");
+        }
         if (folderPath == null) {
             folderPath = Util.createCustomFolder("user.dir");
         }

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -59,8 +59,11 @@ public final class Auklet {
     }
 
     private static void createFolderPath() {
-        folderPath = Util.createCustomFolder("user.dir");
-        if (folderPath == null){
+        folderPath = Util.createCustomFolder("auklet.config.dir");
+        if (folderPath == null) {
+            folderPath = Util.createCustomFolder("user.dir");
+        }
+        if (folderPath == null) {
             folderPath = Util.createCustomFolder("user.home");
         }
         if (folderPath == null) {

--- a/src/main/java/io/auklet/agent/Auklet.java
+++ b/src/main/java/io/auklet/agent/Auklet.java
@@ -61,16 +61,16 @@ public final class Auklet {
     private static void createFolderPath() {
         folderPath = Util.createCustomFolder(System.getenv("AUKLET_CONFIG_DIR"));
         if (folderPath == null) {
-            folderPath = Util.createCustomFolder("auklet.config.dir");
+            folderPath = Util.createCustomFolder(System.getProperty("auklet.config.dir"));
         }
         if (folderPath == null) {
-            folderPath = Util.createCustomFolder("user.dir");
+            folderPath = Util.createCustomFolder(System.getProperty("user.dir"));
         }
         if (folderPath == null) {
-            folderPath = Util.createCustomFolder("user.home");
+            folderPath = Util.createCustomFolder(System.getProperty("user.home"));
         }
         if (folderPath == null) {
-            folderPath = Util.createCustomFolder("java.io.tmpdir");
+            folderPath = Util.createCustomFolder(System.getProperty("java.io.tmpdir"));
         }
         logger.info("Directory to store creds: {}", folderPath);
     }

--- a/src/main/java/io/auklet/agent/Device.java
+++ b/src/main/java/io/auklet/agent/Device.java
@@ -95,17 +95,17 @@ public final class Device {
     }
 
     private static void setCreds(JSONObject jsonObject) {
-        clientPassword = jsonObject.getString("clientPassword");
+        clientPassword = jsonObject.getString("client_password");
         clientUsername = jsonObject.getString("id");
-        clientId = jsonObject.getString("clientId");
+        clientId = jsonObject.getString("client_id");
         organization = jsonObject.getString("organization");
     }
 
     private static void writeCreds(String filename) {
         JSONObject obj = new JSONObject();
-        obj.put("clientPassword", clientPassword);
+        obj.put("client_password", clientPassword);
         obj.put("id", clientUsername);
-        obj.put("clientId", clientId);
+        obj.put("client_id", clientId);
         obj.put("organization", organization);
 
         try (FileOutputStream file = new FileOutputStream(filename)) {

--- a/src/main/java/io/auklet/agent/Util.java
+++ b/src/main/java/io/auklet/agent/Util.java
@@ -67,6 +67,9 @@ public final class Util {
     }
 
     protected static String createCustomFolder(String sysProperty) {
+        if (sysProperty == null || System.getProperty(sysProperty) == null) {
+            return null;
+        }
         String path = System.getProperty(sysProperty) + File.separator + "aukletFiles";
         File newfile = new File(path);
         if (newfile.exists()) {

--- a/src/main/java/io/auklet/agent/Util.java
+++ b/src/main/java/io/auklet/agent/Util.java
@@ -66,18 +66,18 @@ public final class Util {
         return ipAddr;
     }
 
-    protected static String createCustomFolder(String sysProperty) {
-        if (sysProperty == null || System.getProperty(sysProperty) == null) {
+    protected static String createCustomFolder(String filePath) {
+        if (filePath == null) {
             return null;
         }
-        String path = System.getProperty(sysProperty) + File.separator + "aukletFiles";
+        String path = filePath + File.separator + "aukletFiles";
         File newfile = new File(path);
         if (newfile.exists()) {
             logger.debug("Folder already exists");
         } else if (newfile.mkdir()) {
             logger.debug("Folder created");
         } else {
-            logger.debug("Folder was not created for {}", sysProperty);
+            logger.debug("Folder was not created for {}", filePath);
             return null;
         }
 


### PR DESCRIPTION
- Support for adding arbitrary dir for config files for server type applications. 
- It can be set at runtime using `java -Dauklet.config.dir="custom/file/path/dir" MyApp`
- Additional: 
    - Revert `clientPassword` and `clientId` names to `client_password` and `client_id` respectively since the jsonObject returned by the backend contrains the fields in the later format