### PR TITLE
APM-1697: Fix Mqtt publish error and agent hung problem

### DIFF
--- a/src/main/java/io/auklet/agent/DataRetention.java
+++ b/src/main/java/io/auklet/agent/DataRetention.java
@@ -84,7 +84,7 @@ public final class DataRetention {
     }
 
     private static void checkDate() {
-        Timer timer = new Timer();
+        Timer timer = new Timer(true);
         TimerTask hourlyTask = new TimerTask() {
             @Override
             public void run () {

--- a/src/main/java/io/auklet/agent/broker/MQTTClient.java
+++ b/src/main/java/io/auklet/agent/broker/MQTTClient.java
@@ -81,11 +81,13 @@ public class MQTTClient implements Client {
 
             @Override
             public void messageArrived(String topic, MqttMessage message) throws Exception {
-                // TODO handle messages received from the Auklet backend.
+                // TODO: handle messages received from the Auklet backend.
             }
 
             @Override
-            public void deliveryComplete(IMqttDeliveryToken token) { }
+            public void deliveryComplete(IMqttDeliveryToken token) {
+                // TODO: handle what happens when MQTT message delivery completes
+            }
         };
     }
 

--- a/src/main/java/io/auklet/agent/broker/MQTTClient.java
+++ b/src/main/java/io/auklet/agent/broker/MQTTClient.java
@@ -103,7 +103,7 @@ public class MQTTClient implements Client {
 
         options.setConnectionTimeout(60);
         options.setKeepAliveInterval(60);
-        options.setCleanSession(true);
+        options.setCleanSession(false);
         options.setAutomaticReconnect(true);
 
         options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);

--- a/src/main/java/io/auklet/agent/broker/MQTTClient.java
+++ b/src/main/java/io/auklet/agent/broker/MQTTClient.java
@@ -85,9 +85,7 @@ public class MQTTClient implements Client {
             }
 
             @Override
-            public void deliveryComplete(IMqttDeliveryToken token) {
-                logger.info("Message published");
-            }
+            public void deliveryComplete(IMqttDeliveryToken token) { }
         };
     }
 

--- a/src/main/java/io/auklet/agent/broker/MQTTClient.java
+++ b/src/main/java/io/auklet/agent/broker/MQTTClient.java
@@ -86,12 +86,7 @@ public class MQTTClient implements Client {
 
             @Override
             public void deliveryComplete(IMqttDeliveryToken token) {
-                try {
-                    DataRetention.updateDataSent(token.getMessage().getPayload().length);
-                    logger.info("Message published");
-                } catch (MqttException e) {
-                    logger.error("Message was not published", e);
-                }
+                logger.info("Message published");
             }
         };
     }
@@ -108,7 +103,7 @@ public class MQTTClient implements Client {
 
         options.setConnectionTimeout(60);
         options.setKeepAliveInterval(60);
-        options.setCleanSession(false);
+        options.setCleanSession(true);
         options.setAutomaticReconnect(true);
 
         options.setMqttVersion(MqttConnectOptions.MQTT_VERSION_3_1);
@@ -186,6 +181,7 @@ public class MQTTClient implements Client {
                 message.setQos(1); // At Least Once Semantics
                 client.publish("java/events/" + Device.getOrganization() + "/" +
                         Device.getClientUsername(), message);
+                DataRetention.updateDataSent(message.getPayload().length);
                 logger.info("Duplicate message published: {}", message.isDuplicate());
             }
         } catch (MqttException | NullPointerException e) {


### PR DESCRIPTION
- Update the amount of data sent immediately after the client publishes it to mqtt
- This PR makes the `checkDate` timer thread daemon so the agent does not hang after the application exits
