### PR TITLE
Remove shadow JAR plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Plugins
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '2.0.1'
     id 'maven'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'


### PR DESCRIPTION
This PR removes the shadow JAR plugin since it is no longer needed. We will not distribute the Auklet agent as a fat JAR, and testing the agent locally with the fat JAR leads to inconsistencies in test results.