### PR TITLE
Make init/shutdown more defensive

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -201,7 +201,9 @@ public final class Auklet {
                         agent.start();
                         LOGGER.info("Agent started successfully.");
                         return true;
-                    } catch (AukletException e) {
+                    } catch (Exception e) {
+                        // Catch everything so that even programming errors result in an orderly
+                        // shutdown of the agent.
                         shutdown();
                         LOGGER.error("Could not start agent.", e);
                         return false;

--- a/src/main/java/io/auklet/core/AukletApi.java
+++ b/src/main/java/io/auklet/core/AukletApi.java
@@ -80,13 +80,15 @@ public final class AukletApi {
     /** <p>Shuts down the internal HTTP client.</p> */
     public void shutdown() {
         synchronized (this.httpClient) {
-            try {
-                this.httpClient.dispatcher().executorService().shutdown();
-                this.httpClient.connectionPool().evictAll();
-                Cache cache = this.httpClient.cache();
-                if (cache != null) cache.close();
-            } catch (IOException e) {
-                LOGGER.warn("Error while shutting down Auklet API.", e);
+            if (this.httpClient != null) {
+                try {
+                    this.httpClient.dispatcher().executorService().shutdown();
+                    this.httpClient.connectionPool().evictAll();
+                    Cache cache = this.httpClient.cache();
+                    if (cache != null) cache.close();
+                } catch (IOException e) {
+                    LOGGER.warn("Error while shutting down Auklet API.", e);
+                }
             }
         }
     }

--- a/src/main/java/io/auklet/sink/Sink.java
+++ b/src/main/java/io/auklet/sink/Sink.java
@@ -15,7 +15,7 @@ public interface Sink {
     void send(@Nullable Throwable throwable) throws AukletException;
 
     /**
-     * <p>Shuts down this data sink and disconnects/closes any underlying resources</p>.
+     * <p>Shuts down this data sink and disconnects/closes any underlying resources.</p>
      *
      * @throws AukletException if an error occurs while closing the sink or its underlying resources.
      */


### PR DESCRIPTION
This PR makes the init/shutdown methods more defensive:
- Catch `Exception` during `init` instead of `AukletException` to protect against programming errors at runtime, and to ensure that the agent always shuts down cleanly if it fails to init.
- Make `shutdown` methods more defensive (assuming `null` class members) so that they will properly no-op if asked to shutdown due to a bad init.