### PR TITLE
APM-1726: Java Agent Unit Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     build:
         environment:
             TZ: "/usr/share/zoneinfo/America/Detroit"
-        working_directory: ~/app
+        working_directory: ~/app/circleci
         docker:
             - image: circleci/openjdk:9.0.4-jdk-sid-node-browsers
         steps:
@@ -49,9 +49,14 @@ jobs:
                 command: |
                   TERM=dumb ./gradlew dependencies
             - run:
-                name: Run Gradle Tests
+                name: Run Unit Tests
                 command: |
-                  TERM=dumb ./gradlew clean test --info
+                  if [[ -f ~/.localCircleBuild ]]; then
+                    CIRCLE_LOCAL_BUILD=true
+                  else
+                    CIRCLE_LOCAL_BUILD=false
+                  fi
+                  bash .devops/test_and_coverage.sh $CIRCLE_LOCAL_BUILD
             - run:
                 name: Run Whitesource
                 command: |

--- a/.devops/test_and_coverage.sh
+++ b/.devops/test_and_coverage.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+CIRCLE_LOCAL_BUILD=$1
+
+if [[ "$CIRCLE_LOCAL_BUILD" == 'false' ]]; then
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > cc-test-reporter
+  chmod +x cc-test-reporter
+  ./cc-test-reporter before-build
+fi
+
+bash .devops/tests.sh
+
+if [[ "$CIRCLE_LOCAL_BUILD" == 'false' ]]; then
+  # The test reporter will throw a HTTP 409 error if we rebuild in circle because
+  # a test report was already posted for that commit. The below check mitigates this.
+  JACOCO_SOURCE_PATH=src/main/java
+  CC_TEST_REPORTER_ID=c6075c2dabb85c477addbae6616cf72773be68603af742860f40894d0b103c2e
+  # Set -e is disabled momentarily to be able to output the error message to log.txt file.
+  set +e
+  ./cc-test-reporter format-coverage build/reports/jacoco/test/jacocoTestReport.xml --input-type jacoco
+  ./cc-test-reporter upload-coverage 2>&1 | tee exit_message.txt
+  result=$?
+  set -e
+  # Then we check the third line and see if it contains the known error message
+  # and print an error message of our own but let the build succeed.
+  if [ "$(echo `sed -n '2p' exit_message.txt` | cut -d ' ' -f1-5)" = "HTTP 409: A test report" ]; then
+    echo "A test report has already been created for this commit; this build will proceed without updating test coverage data in Code Climate."
+    exit 0
+  else
+    exit $result
+  fi
+fi

--- a/.devops/tests.sh
+++ b/.devops/tests.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+mkdir tmp
+
+touch tmp/io.auklet.core.TestUtil.testDeleteQuietly
+
+gradle test jacocoTestReport
+
+rm -Rf tmp

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'maven'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
+    id 'jacoco'
 }
 
 // Project info
@@ -38,6 +39,8 @@ dependencies {
     compileOnly "com.github.purejavacomm:purejavacomm:1.0.1.RELEASE"
     compileOnly "uk.org.lidalia:sysout-over-slf4j:1.0.2"
     testCompile "org.slf4j:slf4j-simple:1.7.25"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 }
 
 // Compilation configuration
@@ -80,6 +83,15 @@ if (JavaVersion.current().isJava9Compatible()) {
 // Test configuration
 test {
     testLogging.showStandardStreams = true
+    useJUnitPlatform()
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        html.enabled true
+        csv.enabled true
+    }
 }
 
 // Javadoc configuration

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jan 30 10:32:24 EST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/src/test/java/io/auklet/TestAuklet.java
+++ b/src/test/java/io/auklet/TestAuklet.java
@@ -1,0 +1,12 @@
+package io.auklet;
+
+import io.auklet.Auklet;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestAuklet {
+    @Test
+    public void testAuklet() {
+        assertEquals(42, 42);
+    }
+}

--- a/src/test/java/io/auklet/core/TestUtil.java
+++ b/src/test/java/io/auklet/core/TestUtil.java
@@ -1,0 +1,54 @@
+package io.auklet.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TestUtil {
+    @Test
+    void testIsNullOrEmpty() {
+        assertEquals(true, Util.isNullOrEmpty(""));
+        assertEquals(false, Util.isNullOrEmpty("1"));
+    }
+
+    @Test
+    void testOrElse() {
+        assertEquals("0", Util.orElse("0", "1"));
+        assertEquals("1", Util.orElse(null, "1"));
+    }
+
+    @Test
+    void testOrElseNullEmpty() {
+        assertEquals("0", Util.orElseNullEmpty("0", "1"));
+        assertEquals("1", Util.orElseNullEmpty(null, "1"));
+    }
+
+    @Test
+    void testRemoveTrailingSlash() {
+        assertNull(Util.removeTrailingSlash(null));
+        assertEquals("1", Util.removeTrailingSlash("1/"));
+    }
+
+    @Test
+    void testDeleteQuietly() {
+        File file = new File("/tmp/io.auklet.core.TestUtil.testDeleteQuietly");
+        Util.deleteQuietly(file);
+        assertEquals(false, file.isFile());
+    }
+
+    @Test
+    void testWriteUtf8() throws IOException {
+        String pathName = "/tmp/io.auklet.core.TestUtil.testWriteUtf8";
+        File file = new File(pathName);
+        Util.writeUtf8(file, "0");
+        assertEquals("0", new String(Files.readAllBytes(Paths.get(pathName))));
+    }
+}


### PR DESCRIPTION
This PR is to build Unit Tests for the Java Agent.  It uses JUnit 5 to run the tests and JaCoCo for code coverage.

**This is a Work-In-Progress**

Currently JUnit and JaCoCo are setup and a few tests are running within them.  The test results should be uploading to Code Climate and an artifact is being created to view coverage results in HTML format.