### PR TITLE
Make JMI class requirement optional

### DIFF
--- a/src/main/java/io/auklet/platform/JavaPlatform.java
+++ b/src/main/java/io/auklet/platform/JavaPlatform.java
@@ -54,8 +54,9 @@ public class JavaPlatform extends AbstractPlatform {
         // Calculate CPU usage.
         double cpuUsage;
         double loadAvg = OSMX.BEAN.getSystemLoadAverage();
-        if (loadAvg >= 0) {
-            cpuUsage = 100 * (loadAvg / OSMX.BEAN.getAvailableProcessors());
+        int processors = OSMX.BEAN.getAvailableProcessors();
+        if (loadAvg >= 0 && processors > 0) {
+            cpuUsage = 100 * (loadAvg / processors);
         } else {
             cpuUsage = 0d;
         }


### PR DESCRIPTION
In Java 8 Compact Profiles 1/2, and in certain Java 9+ environments, the `java.lang.management` classes are not available. This PR adds support for these scenarios by allowing these classes not to exist, and returning relevant no-op values for the affected methods.