### PR TITLE
Allow some tasks to be cancelled without logging

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -398,22 +398,6 @@ public final class Auklet {
     }
 
     /**
-     * <p>Executes the given one-shot task immediately in the Auklet agent's daemon executor thread.</p>
-     *
-     * @param command the task to execute.
-     * @throws AukletException to wrap any underlying exceptions.
-     * @see ExecutorService#execute(Runnable)
-     */
-    @NonNull public void doOneShotTask(@NonNull Runnable command) throws AukletException {
-        if (command == null) throw new AukletException("Daemon task is null.");
-        try {
-            DAEMON.execute(command);
-        } catch (RejectedExecutionException e) {
-            throw new AukletException("Could not schedule one-shot task.", e);
-        }
-    }
-
-    /**
      * <p>Schedules the given one-shot task to run on the Auklet agent's daemon executor thread.</p>
      *
      * @param command the task to execute.

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -398,6 +398,22 @@ public final class Auklet {
     }
 
     /**
+     * <p>Executes the given one-shot task immediately in the Auklet agent's daemon executor thread.</p>
+     *
+     * @param command the task to execute.
+     * @throws AukletException to wrap any underlying exceptions.
+     * @see ExecutorService#execute(Runnable)
+     */
+    @NonNull public void doOneShotTask(@NonNull Runnable command) throws AukletException {
+        if (command == null) throw new AukletException("Daemon task is null.");
+        try {
+            DAEMON.execute(command);
+        } catch (RejectedExecutionException e) {
+            throw new AukletException("Could not schedule one-shot task.", e);
+        }
+    }
+
+    /**
      * <p>Schedules the given one-shot task to run on the Auklet agent's daemon executor thread.</p>
      *
      * @param command the task to execute.

--- a/src/main/java/io/auklet/config/DataUsageTracker.java
+++ b/src/main/java/io/auklet/config/DataUsageTracker.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -40,7 +40,8 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
                 Thread.currentThread().interrupt();
             }
         }
-        if (t != null) LOGGER.warn("Exception in Auklet daemon task.", t);
+        if (t instanceof CancellationException) LOGGER.warn("Auklet daemon task cancelled.", t);
+        else if (t != null) LOGGER.warn("Exception in Auklet daemon task.", t);
     }
 
     /* Decorates CancelSilentlyFutureTasks so that afterExecute() knows about them. */

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -45,6 +45,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
     }
 
     /* Decorates CancelSilentlyFutureTasks so that afterExecute() knows about them. */
+    @Override
     protected <V> RunnableScheduledFuture<V> decorateTask(
             Runnable r, RunnableScheduledFuture<V> task) {
         return r instanceof CancelSilentlyRunnable ? new CancelSilentlyRSF<>(task) : task;
@@ -55,7 +56,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
      *
      * {@inheritDoc}
      */
-    public static abstract class CancelSilentlyRunnable implements Runnable {};
+    public abstract static class CancelSilentlyRunnable implements Runnable {}
 
     /*
      * Internal version of CancelSilentlyRunnable that is required by the

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -33,7 +33,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
             try {
                 if (future.isDone()) future.get();
             } catch (CancellationException ce) {
-                if (!(future instanceof CancelSilentlyFutureTask)) t = ce;
+                if (!(future instanceof CancelSilentlyRSF)) t = ce;
             } catch (ExecutionException ee) {
                 t = ee.getCause();
             } catch (InterruptedException ie) {
@@ -43,19 +43,46 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
         if (t != null) LOGGER.warn("Exception in Auklet daemon task.", t);
     }
 
+    /* Decorates CancelSilentlyFutureTasks so that afterExecute() knows about them. */
+    protected <V> RunnableScheduledFuture<V> decorateTask(
+            Runnable r, RunnableScheduledFuture<V> task) {
+        return r instanceof CancelSilentlyRunnable ? new CancelSilentlyRSF<>(task) : task;
+    }
+
     /**
-     * A {@link FutureTask} that the {@link AukletDaemonExecutor} will not log if it is cancelled.
+     * A {@link Runnable} that the {@link AukletDaemonExecutor} will not log if it is cancelled.
      *
      * {@inheritDoc}
      */
-    public static final class CancelSilentlyFutureTask<V> extends FutureTask<V> {
-        /** {@inheritDoc} */
-        public CancelSilentlyFutureTask(Callable<V> callable) {
-            super(callable);
-        }
-        /** {@inheritDoc} */
-        public CancelSilentlyFutureTask(Runnable runnable, V result) {
-            super(runnable, result);
+    public static abstract class CancelSilentlyRunnable implements Runnable {};
+
+    /*
+     * Internal version of CancelSilentlyRunnable that is required by the
+     * decorateTask() methods to pass to afterExecute() the fact that cancellation
+     * should not be logged.
+     */
+    private static final class CancelSilentlyRSF<V> implements RunnableScheduledFuture<V> {
+        private final RunnableScheduledFuture<V> task;
+        private CancelSilentlyRSF(RunnableScheduledFuture<V> task) { this.task = task; }
+        @Override
+        public boolean isPeriodic() { return task.isPeriodic(); }
+        @Override
+        public long getDelay(TimeUnit unit) { return task.getDelay(unit); }
+        @Override
+        public int compareTo(Delayed o) { return task.compareTo(o); }
+        @Override
+        public void run() { task.run(); }
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) { return task.cancel(mayInterruptIfRunning); }
+        @Override
+        public boolean isCancelled() { return task.isCancelled(); }
+        @Override
+        public boolean isDone() { return task.isDone(); }
+        @Override
+        public V get() throws InterruptedException, ExecutionException { return task.get(); }
+        @Override
+        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return task.get(timeout, unit);
         }
     }
 

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -46,14 +46,14 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
     /**
      * A {@link FutureTask} that the {@link AukletDaemonExecutor} will not log if it is cancelled.
      *
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public static final class CancelSilentlyFutureTask<V> extends FutureTask<V> {
-        /** @inheritDoc */
+        /** {@inheritDoc} */
         public CancelSilentlyFutureTask(Callable<V> callable) {
             super(callable);
         }
-        /** @inheritDoc */
+        /** {@inheritDoc} */
         public CancelSilentlyFutureTask(Runnable runnable, V result) {
             super(runnable, result);
         }


### PR DESCRIPTION
Some daemon tasks, like `DataUsageTracker`'s task to write data to disk, should not be logged by `AukletDaemonExecutor` if they are cancelled because cancelling the task is part of the happy-path logic. This PR adds `CancelSilentlyFutureTask` (which is `Runnable` and thus passable to `Auklet.scheduleOneShotTask`) which is honored by `AukletDaemonExecutor` to skip logging of cancelled tasks.