### PR TITLE
Hide MQTT disconnect errors

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -48,7 +48,7 @@ public final class Auklet {
     public static final String VERSION;
     private static final Logger LOGGER = LoggerFactory.getLogger(Auklet.class);
     private static final Object LOCK = new Object();
-    private static final ScheduledExecutorService DAEMON = new AukletDaemonExecutor(1, Util.createDaemonThreadFactory("Auklet"));
+    private static final AukletDaemonExecutor DAEMON = new AukletDaemonExecutor(1, Util.createDaemonThreadFactory("Auklet"));
     private static Auklet agent = null;
 
     private final String appId;
@@ -285,8 +285,11 @@ public final class Auklet {
                         LOGGER.debug("Ignoring shutdown request because agent is null.");
                         return;
                     }
+                    // Do not log cancelled tasks during shutdown.
+                    DAEMON.logCancelExceptions(false);
                     agent.doShutdown(false);
                     agent = null;
+                    DAEMON.logCancelExceptions(true);
                 }
             }
         };

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.*;
 public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AukletDaemonExecutor.class);
-    private final Object LOCK = new Object();
+    private final Object lock = new Object();
     private boolean logCancelExceptions = true;
 
     /**
@@ -35,7 +35,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
      * @param enabled {@code true} to log these exceptions, {@code false} to skip logging.
      */
     public void logCancelExceptions(boolean enabled) {
-        synchronized(LOCK) { logCancelExceptions = enabled; }
+        synchronized(lock) { logCancelExceptions = enabled; }
     }
 
     /* Logs exceptions that occur in tasks. */
@@ -55,7 +55,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
         }
         if (t instanceof CancellationException) {
             boolean logThis;
-            synchronized(LOCK) { logThis = logCancelExceptions; }
+            synchronized(lock) { logThis = logCancelExceptions; }
             if (logThis) LOGGER.warn("Auklet daemon task cancelled.", t);
         }
         else if (t != null) LOGGER.warn("Exception in Auklet daemon task.", t);

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -1,5 +1,6 @@
 package io.auklet.misc;
 
+import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,9 +12,12 @@ import java.util.concurrent.*;
  * <p>To prevent an infinite loop, exceptions that are logged by this executor are not submitted
  * to the Auklet data sink and are only logged to SLF4J.</p>
  */
+@ThreadSafe
 public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AukletDaemonExecutor.class);
+    private final Object LOCK = new Object();
+    private boolean logCancelExceptions = true;
 
     /**
      * Constructor.
@@ -23,6 +27,15 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
      */
     public AukletDaemonExecutor(int corePoolSize, ThreadFactory threadFactory) {
         super(corePoolSize, threadFactory);
+    }
+
+    /**
+     * <p>Configures the executor to enable/disable logging of {@link CancellationException}s.</p>
+     *
+     * @param enabled {@code true} to log these exceptions, {@code false} to skip logging.
+     */
+    public void logCancelExceptions(boolean enabled) {
+        synchronized(LOCK) { logCancelExceptions = enabled; }
     }
 
     /* Logs exceptions that occur in tasks. */
@@ -40,7 +53,11 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
                 Thread.currentThread().interrupt();
             }
         }
-        if (t instanceof CancellationException) LOGGER.warn("Auklet daemon task cancelled.", t);
+        if (t instanceof CancellationException) {
+            boolean logThis;
+            synchronized(LOCK) { logThis = logCancelExceptions; }
+            if (logThis) LOGGER.warn("Auklet daemon task cancelled.", t);
+        }
         else if (t != null) LOGGER.warn("Exception in Auklet daemon task.", t);
     }
 

--- a/src/main/java/io/auklet/sink/AukletIoSink.java
+++ b/src/main/java/io/auklet/sink/AukletIoSink.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.concurrent.ScheduledExecutorService;
 
 /** <p>The default Auklet data sink, which sends data to {@code auklet.io} via MQTT.</p> */
 @ThreadSafe

--- a/src/main/java/io/auklet/sink/AukletIoSink.java
+++ b/src/main/java/io/auklet/sink/AukletIoSink.java
@@ -28,7 +28,7 @@ public final class AukletIoSink extends AbstractSink {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AukletIoSink.class);
     private final Object lock = new Object();
-    private ScheduledExecutorService executorService;
+    private AukletDaemonExecutor executorService;
     private MqttAsyncClient client;
 
     /**
@@ -83,11 +83,15 @@ public final class AukletIoSink extends AbstractSink {
             super.shutdown();
             if (this.client != null) {
                 if (this.client.isConnected()) {
+                    this.executorService.logCancelExceptions(false);
                     try {
                         // Wait 2 seconds for work to quiesce and 1 second for disconnect to finish.
                         this.client.disconnect(2000L).waitForCompletion(1000L);
                     } catch (MqttException e) {
-                        LOGGER.warn("Error while disconnecting MQTT client.", e);
+                        // TODO remove this conditional after upgrading Paho to fix this
+                        if (!e.getMessage().equals("Timed out waiting for a response from the server")) {
+                            LOGGER.warn("Error while disconnecting MQTT client.", e);
+                        }
                         try {
                             // Do not wait for work to quiesce.
                             // Wait 1ms to disconnect (effectively do not wait, but if we say 0ms


### PR DESCRIPTION
This is a workaround for https://github.com/aukletio/Auklet-Agent-Java/pull/57.

Changes:
- MQTT disconnect exception is not logged.
- `CancellationException`s are not logged while the agent is shutting down. Sometimes MQTT disconnect causes these exceptions if their corresponding thread tasks do not complete before the JVM begins to shutdown. In general, it's good not to log _any_ `CancellationException`s during agent shutdown (because it makes sense for tasks to be cancelled during that timeframe), so this change will _not_ be reverted when https://github.com/aukletio/Auklet-Agent-Java/pull/57 is merged, and thus this PR is labeled as an enhancement. 