### PR TITLE
Fix retrieval of agent version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ description = 'Official Auklet SDK for Java and other JVM languages.'
 buildConfig {
     buildConfigField('String', 'AGENT_VERSION', "\"${version}\"")
 }
-tasks.withType(BuildConfigTask::class) {
+generateBuildConfig {
     addGeneratedAnnotation = false
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,8 @@
 // Plugins
 plugins {
+    id 'idea'
     id 'java'
+    id 'com.github.gmazzo.buildconfig' version '1.3.6'
     id 'maven'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
@@ -10,6 +12,16 @@ plugins {
 group "${theGroup}"
 version "${theVersion}"
 description = 'Official Auklet SDK for Java and other JVM languages.'
+buildConfig {
+    buildConfigField('String', 'AGENT_VERSION', "\"${version}\"")
+}
+
+// IDE configuration
+idea {
+    module {
+        generatedSourceDirs += file('build/generated/source/buildConfig/main')
+    }
+}
 
 // Java version
 sourceCompatibility = 7

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,9 @@ description = 'Official Auklet SDK for Java and other JVM languages.'
 buildConfig {
     buildConfigField('String', 'AGENT_VERSION', "\"${version}\"")
 }
+tasks.withType(BuildConfigTask::class) {
+    addGeneratedAnnotation = false
+}
 
 // IDE configuration
 idea {

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -69,7 +69,7 @@ public final class Auklet {
         String version = "unknown";
         try {
             version = BuildConfig.AGENT_VERSION;
-        } catch (Throwable e) {
+        } catch (RuntimeException | NoClassDefFoundError e) {
             LOGGER.warn("Could not obtain Auklet agent version from manifest.", e);
         }
         LOGGER.info("Auklet Agent version {}", version);

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -72,8 +72,8 @@ public final class Auklet {
         } catch (Throwable e) {
             LOGGER.warn("Could not obtain Auklet agent version from manifest.", e);
         }
+        LOGGER.info("Auklet Agent version {}", version);
         VERSION = version;
-        LOGGER.info("Auklet agent version " + VERSION);
         // Initialize the Auklet agent if requested via env var or JVM sysprop.
         String fromEnv = System.getenv("AUKLET_AUTO_START");
         String fromProp = System.getProperty("auklet.auto.start");

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -19,7 +19,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.security.CodeSource;
 import java.util.concurrent.*;
+import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
 /**
@@ -68,13 +72,34 @@ public final class Auklet {
     static {
         // Extract Auklet agent version from the manifest.
         String version = "unknown";
-        try (InputStream manifestStream = Auklet.class.getClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")) {
-            if (manifestStream != null) {
-                Manifest manifest = new Manifest(manifestStream);
-                version = manifest.getMainAttributes().getValue("Implementation-Version");
-                version = Util.orElse(version, "unknown");
+        try {
+            // We can't use Auklet.class.getResourceAsStream() here because the classloader
+            // in question is not a URLClassLoader pointing to the Auklet agent JAR. This is
+            // because we're in a static initializer. Because of this, we have to obtain a
+            // URL object pointing to the JAR file on disk and load that as a JarFile object.
+            CodeSource cs = Auklet.class.getProtectionDomain().getCodeSource();
+            // We cannot control if the CodeSource is available. If it is not, don't bother
+            // notifying the end user.
+            if (cs != null) {
+                URL aukletUrl = cs.getLocation();
+                File aukletFile;
+                try { aukletFile = new File(aukletUrl.toURI()); }
+                catch (URISyntaxException e) { aukletFile = new File(aukletUrl.getPath()); }
+                // If the JAR file doesn't "exist", chances are there are some permissions that
+                // prevent us from reading it in this manner. Don't notify the end user.
+                if (aukletFile.exists()) {
+                    Manifest manifest = new JarFile(aukletFile).getManifest();
+                    if (manifest == null) {
+                        // If the manifest somehow cannot be found, that implies that the
+                        // Auklet agent JAR may have been modified. Warn the user about this.
+                        LOGGER.warn("Auklet agent JAR located, but no manifest was found. Has the JAR been modified?");
+                    } else {
+                        version = manifest.getMainAttributes().getValue("Implementation-Version");
+                        version = Util.orElse(version, "unknown");
+                        LOGGER.info("Auklet Agent version {}", version);
+                    }
+                }
             }
-            LOGGER.info("Auklet Agent version {}", version);
         } catch (SecurityException | IOException e) {
             LOGGER.warn("Could not obtain Auklet agent version from manifest.", e);
         }


### PR DESCRIPTION
Not sure when this broke (or if it ever worked), but the agent version has not been retrieved correctly from the JAR manifest's `Implementation-Version` attribute. This approach, even when fixed for Java SE, would not work for Android.

This PR adds a Gradle plugin that generates a `BuildConfig` Java class during the build with our version number, which we then reference at runtime to get the agent version. This fixes both Java SE and Android.