### PR TITLE
Rename config dir to .auklet

### DIFF
--- a/src/main/java/io/auklet/platform/AndroidPlatform.java
+++ b/src/main/java/io/auklet/platform/AndroidPlatform.java
@@ -51,7 +51,7 @@ public class AndroidPlatform extends AbstractPlatform {
      * exactly 1 element
      */
     @Override public List<String> getPossibleConfigDirs(@Nullable String fromConfig) {
-        return Collections.singletonList(this.context.getFilesDir().getPath() + "/aukletFiles");
+        return Collections.singletonList(this.context.getFilesDir().getPath() + "/.auklet");
     }
 
     @Override public void addSystemMetrics(@NonNull MessagePacker msgpack) throws IOException {

--- a/src/main/java/io/auklet/platform/JavaPlatform.java
+++ b/src/main/java/io/auklet/platform/JavaPlatform.java
@@ -34,7 +34,7 @@ public class JavaPlatform extends AbstractPlatform {
         // Drop any env vars/sysprops whose value is null, and append the auklet subdir to each remaining value.
         List<String> filteredConfigDirs = new ArrayList<>();
         for (String dir : possibleConfigDirs) {
-            if (!Util.isNullOrEmpty(dir)) filteredConfigDirs.add(Util.removeTrailingSlash(dir) + "/aukletFiles");
+            if (!Util.isNullOrEmpty(dir)) filteredConfigDirs.add(Util.removeTrailingSlash(dir) + "/.auklet");
         }
         return filteredConfigDirs;
     }


### PR DESCRIPTION
This PR renames the `aukletFiles` dir to `.auklet` so that the config dir is hidden by default.