### PR TITLE
Miscellaneous fixes/cleanup

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -142,7 +142,7 @@ public final class Auklet {
             this.platform = new AndroidPlatform(androidContext);
         }
         this.configDir = platform.obtainConfigDir(Util.getValue(config.getConfigDir(), "AUKLET_CONFIG_DIR", "auklet.config.dir"));
-        if (configDir == null) throw new AukletException("Could not find or create any config directory; see previous logged errors for details");
+        if (configDir == null) throw new AukletException("Could not find or create any config directory; see previous logged errors for details.");
 
         LOGGER.debug("Configuring agent resources.");
         this.api = new AukletApi(apiKey);

--- a/src/main/java/io/auklet/config/AbstractConfigFile.java
+++ b/src/main/java/io/auklet/config/AbstractConfigFile.java
@@ -11,6 +11,9 @@ import java.io.File;
 /**
  * <p>Descendants of this class represent a configuration file located inside the Auklet agent's
  * configuration directory.</p>
+ *
+ * <p>This class is not inherently thread-safe, but any subclasses that fully synchronize access
+ * to the file object can be thread-safe.</p>
  */
 @NotThreadSafe
 public abstract class AbstractConfigFile extends HasAgent {

--- a/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
+++ b/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
@@ -37,4 +37,13 @@ public abstract class AbstractJsonConfigFileFromApi extends AbstractConfigFileFr
         }
     }
 
+    @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
+        if (contents == null) throw new AukletException("Input is null.");
+        try {
+            Util.writeUtf8(this.file, contents.toString());
+        } catch (IOException e) {
+            throw new AukletException("Could not save JSON file to disk.", e);
+        }
+    }
+
 }

--- a/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
+++ b/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
@@ -24,7 +24,7 @@ public abstract class AbstractJsonConfigFileFromApi extends AbstractConfigFileFr
      * @throws AukletException if the request is {@code null}, or if the request fails or has an error.
      */
     @NonNull protected final Json makeJsonRequest(@NonNull Request.Builder request) throws AukletException {
-        if (request == null) throw new AukletException("JSON HTTP request is null");
+        if (request == null) throw new AukletException("JSON HTTP request is null.");
         try (Response response = this.getAgent().getApi().doRequest(request)) {
             String responseString = response.body().string();
             if (response.isSuccessful()) {

--- a/src/main/java/io/auklet/config/AukletIoBrokers.java
+++ b/src/main/java/io/auklet/config/AukletIoBrokers.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * <p>This file contains MQTT connection information for sending data to {@code auklet.io}.</p>
+ * <p>This config file contains MQTT connection information for sending data to {@code auklet.io}.</p>
  */
 @NotThreadSafe
 public final class AukletIoBrokers extends AbstractJsonConfigFileFromApi {

--- a/src/main/java/io/auklet/config/AukletIoBrokers.java
+++ b/src/main/java/io/auklet/config/AukletIoBrokers.java
@@ -58,13 +58,4 @@ public final class AukletIoBrokers extends AbstractJsonConfigFileFromApi {
         return this.makeJsonRequest(request);
     }
 
-    @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
-        if (contents == null) throw new AukletException("Input is null.");
-        try {
-            Util.writeUtf8(this.file, contents.toString());
-        } catch (IOException e) {
-            throw new AukletException("Could not save MQTT brokers list to disk.", e);
-        }
-    }
-
 }

--- a/src/main/java/io/auklet/config/AukletIoBrokers.java
+++ b/src/main/java/io/auklet/config/AukletIoBrokers.java
@@ -60,7 +60,11 @@ public final class AukletIoBrokers extends AbstractJsonConfigFileFromApi {
 
     @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
         if (contents == null) throw new AukletException("Input is null.");
-        Util.writeUtf8(this.file, contents.toString());
+        try {
+            Util.writeUtf8(this.file, contents.toString());
+        } catch (IOException e) {
+            throw new AukletException("Could not save MQTT brokers list to disk.", e);
+        }
     }
 
 }

--- a/src/main/java/io/auklet/config/AukletIoCert.java
+++ b/src/main/java/io/auklet/config/AukletIoCert.java
@@ -77,7 +77,11 @@ public final class AukletIoCert extends AbstractConfigFileFromApi<String> {
 
     @Override protected void writeToDisk(@NonNull String contents) throws AukletException {
         if (Util.isNullOrEmpty(contents)) throw new AukletException("Input is null or empty.");
-        Util.writeUtf8(this.file, contents);
+        try {
+            Util.writeUtf8(this.file, contents);
+        } catch (IOException e) {
+            throw new AukletException("Could not save MQTT CA cert to disk.", e);
+        }
     }
 
 }

--- a/src/main/java/io/auklet/config/AukletIoCert.java
+++ b/src/main/java/io/auklet/config/AukletIoCert.java
@@ -16,7 +16,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 
 /**
- * <p>This is the CA certificate for establishing SSL connections to the {@code auklet.io} data pipeline.</p>
+ * <p>This config file contains the MQTT CA certificate for {@code auklet.io}.</p>
  */
 @NotThreadSafe
 public final class AukletIoCert extends AbstractConfigFileFromApi<String> {

--- a/src/main/java/io/auklet/config/DataUsageLimit.java
+++ b/src/main/java/io/auklet/config/DataUsageLimit.java
@@ -74,7 +74,11 @@ public final class DataUsageLimit extends AbstractJsonConfigFileFromApi {
 
     @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
         if (contents == null) throw new AukletException("Input is null.");
-        Util.writeUtf8(this.file, contents.toString());
+        try {
+            Util.writeUtf8(this.file, contents.toString());
+        } catch (IOException e) {
+            throw new AukletException("Could not save data usage limits to disk.", e);
+        }
     }
 
     /**

--- a/src/main/java/io/auklet/config/DataUsageLimit.java
+++ b/src/main/java/io/auklet/config/DataUsageLimit.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /**
- * <p>The <i>data usage limit file</i> contains the configuration values, for this agent's app ID,
+ * <p>This config file contains the configuration values, defined at the Auklet application (app ID) level,
  * that control how much data the agent emits to the sink.</p>
  */
 @NotThreadSafe

--- a/src/main/java/io/auklet/config/DataUsageLimit.java
+++ b/src/main/java/io/auklet/config/DataUsageLimit.java
@@ -72,15 +72,6 @@ public final class DataUsageLimit extends AbstractJsonConfigFileFromApi {
         return this.makeJsonRequest(request);
     }
 
-    @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
-        if (contents == null) throw new AukletException("Input is null.");
-        try {
-            Util.writeUtf8(this.file, contents.toString());
-        } catch (IOException e) {
-            throw new AukletException("Could not save data usage limits to disk.", e);
-        }
-    }
-
     /**
      * <p>Updates this object with the config values from the JSON.</p>
      *

--- a/src/main/java/io/auklet/config/DataUsageTracker.java
+++ b/src/main/java/io/auklet/config/DataUsageTracker.java
@@ -15,8 +15,8 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
- * <p>The <i>data usage tracker file</i> is used to persist between restarts the amount of data that has
- * been sent by the Auklet agent to the sink.</p>
+ * <p>This config file persists between agent restarts the amount of data that has been sent by
+ * the Auklet agent to the sink, pursuant to the defined {@link DataUsageLimit}.</p>
  */
 @NotThreadSafe
 public final class DataUsageTracker extends AbstractConfigFile {

--- a/src/main/java/io/auklet/config/DataUsageTracker.java
+++ b/src/main/java/io/auklet/config/DataUsageTracker.java
@@ -6,7 +6,7 @@ import io.auklet.AukletException;
 import io.auklet.misc.AukletDaemonExecutor;
 import io.auklet.misc.Util;
 import mjson.Json;
-import net.jcip.annotations.NotThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
  * <p>This config file persists between agent restarts the amount of data that has been sent by
  * the Auklet agent to the sink, pursuant to the defined {@link DataUsageLimit}.</p>
  */
-@NotThreadSafe
+@ThreadSafe
 public final class DataUsageTracker extends AbstractConfigFile {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataUsageTracker.class);
@@ -53,7 +53,11 @@ public final class DataUsageTracker extends AbstractConfigFile {
      *
      * @return the number of bytes sent.
      */
-    public long getBytesSent() { return this.bytesSent; }
+    public long getBytesSent() {
+        synchronized (lock) {
+            return this.bytesSent;
+        }
+    }
 
     /**
      * <p>Adds the input number of bytes to the current amount of bytes sent.</p>
@@ -62,14 +66,18 @@ public final class DataUsageTracker extends AbstractConfigFile {
      */
     public void addMoreData(long moreBytes) {
         if (moreBytes < 1) return;
-        this.bytesSent += moreBytes;
-        this.saveUsage(this.bytesSent);
+        synchronized (lock) {
+            this.bytesSent += moreBytes;
+            this.saveUsage(this.bytesSent);
+        }
     }
 
     /** <p>Resets the data usage to zero.</p> */
     public void reset() {
-        this.bytesSent = 0L;
-        this.saveUsage(this.bytesSent);
+        synchronized (lock) {
+            this.bytesSent = 0L;
+            this.saveUsage(this.bytesSent);
+        }
     }
 
     /**
@@ -80,24 +88,22 @@ public final class DataUsageTracker extends AbstractConfigFile {
     private void saveUsage(final long givenUsage) {
         try {
             // If there is already a pending write task, cancel it.
-            synchronized (this.lock) {
-                if (this.currentWriteTask != null) currentWriteTask.cancel(false);
-                // Queue the new write task.
-                this.currentWriteTask = this.getAgent().scheduleOneShotTask(new AukletDaemonExecutor.CancelSilentlyRunnable() {
-                    @Override
-                    public void run() {
-                        // This task is no longer pending, so clear its status.
-                        synchronized (lock) {
-                            currentWriteTask = null;
-                        }
-                        try {
-                            writeUsageToDisk(givenUsage);
-                        } catch (IOException | SecurityException e) {
-                            LOGGER.warn("Could not save data usage to disk.", e);
-                        }
+            if (this.currentWriteTask != null) currentWriteTask.cancel(false);
+            // Queue the new write task.
+            this.currentWriteTask = this.getAgent().scheduleOneShotTask(new AukletDaemonExecutor.CancelSilentlyRunnable() {
+                @Override
+                public void run() {
+                    // This task is no longer pending, so clear its status.
+                    synchronized (lock) {
+                        currentWriteTask = null;
                     }
-                }, 5, TimeUnit.SECONDS); // 5-second cooldown.
-            }
+                    try {
+                        writeUsageToDisk(givenUsage);
+                    } catch (IOException | SecurityException e) {
+                        LOGGER.warn("Could not save data usage to disk.", e);
+                    }
+                }
+            }, 5, TimeUnit.SECONDS); // 5-second cooldown.
         } catch (AukletException e) {
             LOGGER.warn("Could not queue data usage save task.", e);
         }

--- a/src/main/java/io/auklet/config/DeviceAuth.java
+++ b/src/main/java/io/auklet/config/DeviceAuth.java
@@ -135,7 +135,7 @@ public final class DeviceAuth extends AbstractJsonConfigFileFromApi {
     }
 
     @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {
-        if (contents == null) throw new AukletException("Input is null");
+        if (contents == null) throw new AukletException("Input is null.");
         try {
             // Encrypt and save the JSON string to disk.
             this.aesCipher.init(Cipher.ENCRYPT_MODE, this.aesKey);

--- a/src/main/java/io/auklet/config/DeviceAuth.java
+++ b/src/main/java/io/auklet/config/DeviceAuth.java
@@ -23,8 +23,8 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 
 /**
- * <p>The <i>device authentication file</i> contains the Auklet organization ID to which the application ID
- * belongs, as well as the credentials used to authenticate to the {@code auklet.io} data pipeline.</p>
+ * <p>This config file contains the Auklet organization ID to which the application ID belongs,
+ * as well as the credentials used to authenticate to the {@code auklet.io} data pipeline.</p>
  */
 @NotThreadSafe
 public final class DeviceAuth extends AbstractJsonConfigFileFromApi {

--- a/src/main/java/io/auklet/core/AukletApi.java
+++ b/src/main/java/io/auklet/core/AukletApi.java
@@ -81,15 +81,13 @@ public final class AukletApi {
     /** <p>Shuts down the internal HTTP client.</p> */
     public void shutdown() {
         synchronized (this.httpClient) {
-            if (this.httpClient != null) {
-                try {
-                    this.httpClient.dispatcher().executorService().shutdown();
-                    this.httpClient.connectionPool().evictAll();
-                    Cache cache = this.httpClient.cache();
-                    if (cache != null) cache.close();
-                } catch (IOException e) {
-                    LOGGER.warn("Error while shutting down Auklet API.", e);
-                }
+            try {
+                this.httpClient.dispatcher().executorService().shutdown();
+                this.httpClient.connectionPool().evictAll();
+                Cache cache = this.httpClient.cache();
+                if (cache != null) cache.close();
+            } catch (IOException e) {
+                LOGGER.warn("Error while shutting down Auklet API.", e);
             }
         }
     }

--- a/src/main/java/io/auklet/core/AukletExceptionHandler.java
+++ b/src/main/java/io/auklet/core/AukletExceptionHandler.java
@@ -1,5 +1,6 @@
 package io.auklet.core;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.auklet.Auklet;
 import net.jcip.annotations.Immutable;
 import org.slf4j.Logger;
@@ -11,7 +12,7 @@ public final class AukletExceptionHandler implements Thread.UncaughtExceptionHan
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AukletExceptionHandler.class);
 
-    @Override public void uncaughtException(Thread t, Throwable e) {
+    @Override public void uncaughtException(@Nullable Thread t, @Nullable Throwable e) {
         if (e == null) return;
         if (!(e instanceof ThreadDeath)) {
             LOGGER.debug("Sending uncaught exception.");

--- a/src/main/java/io/auklet/core/DataUsageMonitor.java
+++ b/src/main/java/io/auklet/core/DataUsageMonitor.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * <p>This class handles tracking of data usage, enforcement of data usage limits, and periodic refresh
- * of the data usage limit config.</p>
+ * of the {@link DataUsageLimit} config.</p>
  *
  * <p>The enforcement of the data usage limit provided by this class is fuzzy by nature; due to a lack
  * of OS integration to sniff all traffic that's being sent across the wire, this class will always

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -1,5 +1,8 @@
 package io.auklet.misc;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import net.jcip.annotations.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +14,7 @@ import java.util.concurrent.*;
  * <p>To prevent an infinite loop, exceptions that are logged by this executor are not submitted
  * to the Auklet data sink and are only logged to SLF4J.</p>
  */
+@Immutable
 public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AukletDaemonExecutor.class);
@@ -21,12 +25,12 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
      * @param corePoolSize the number of threads in this executor.
      * @param threadFactory the thread factory to use.
      */
-    public AukletDaemonExecutor(int corePoolSize, ThreadFactory threadFactory) {
+    public AukletDaemonExecutor(int corePoolSize, @NonNull ThreadFactory threadFactory) {
         super(corePoolSize, threadFactory);
     }
 
     /* Logs exceptions that occur in tasks. */
-    @Override protected void afterExecute(Runnable r, Throwable t) {
+    @Override protected void afterExecute(@Nullable Runnable r, @Nullable Throwable t) {
         super.afterExecute(r, t);
         if (t == null && r instanceof Future<?>) {
             Future<?> future = (Future<?>) r;
@@ -47,7 +51,8 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
     /* Decorates CancelSilentlyFutureTasks so that afterExecute() knows about them. */
     @Override
     protected <V> RunnableScheduledFuture<V> decorateTask(
-            Runnable r, RunnableScheduledFuture<V> task) {
+            @Nullable Runnable r, @NonNull RunnableScheduledFuture<V> task) {
+        if (task == null) throw new IllegalArgumentException("Task is null.");
         return r instanceof CancelSilentlyRunnable ? new CancelSilentlyRSF<>(task) : task;
     }
 
@@ -65,13 +70,16 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
      */
     private static final class CancelSilentlyRSF<V> implements RunnableScheduledFuture<V> {
         private final RunnableScheduledFuture<V> task;
-        private CancelSilentlyRSF(RunnableScheduledFuture<V> task) { this.task = task; }
+        private CancelSilentlyRSF(@NonNull RunnableScheduledFuture<V> task) {
+            if (task == null) throw new IllegalArgumentException("Task is null");
+            this.task = task;
+        }
         @Override
         public boolean isPeriodic() { return task.isPeriodic(); }
         @Override
-        public long getDelay(TimeUnit unit) { return task.getDelay(unit); }
+        public long getDelay(@Nullable TimeUnit unit) { return task.getDelay(unit); }
         @Override
-        public int compareTo(Delayed o) { return task.compareTo(o); }
+        public int compareTo(@Nullable Delayed o) { return task.compareTo(o); }
         @Override
         public void run() { task.run(); }
         @Override
@@ -83,7 +91,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
         @Override
         public V get() throws InterruptedException, ExecutionException { return task.get(); }
         @Override
-        public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        public V get(long timeout, @Nullable TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
             return task.get(timeout, unit);
         }
     }

--- a/src/main/java/io/auklet/misc/PahoLogger.java
+++ b/src/main/java/io/auklet/misc/PahoLogger.java
@@ -1,5 +1,7 @@
 package io.auklet.misc;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import net.jcip.annotations.NotThreadSafe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,13 +20,14 @@ import java.util.*;
  * <p>These loggers are designed to work with JUL resource bundles, but do not require them.</p>
  */
 @NotThreadSafe
+@SuppressWarnings("unused")
 public final class PahoLogger implements org.eclipse.paho.client.mqttv3.logging.Logger {
 
     private Logger logger = null;
     private ResourceBundle bundle;
     private String context;
 
-    @Override public void initialise(ResourceBundle messageCatalog, String loggerID, String resourceName) {
+    @Override public void initialise(@Nullable ResourceBundle messageCatalog, @NonNull String loggerID, @Nullable String resourceName) {
         if (loggerID == null) throw new IllegalArgumentException("loggerID is null.");
         logger = LoggerFactory.getLogger(loggerID);
         bundle = messageCatalog;
@@ -32,7 +35,7 @@ public final class PahoLogger implements org.eclipse.paho.client.mqttv3.logging.
     }
 
     @Override
-    public void setResourceName(String logContext) { context = logContext; }
+    public void setResourceName(@Nullable String logContext) { context = logContext; }
 
     @Override public boolean isLoggable(int level) {
         switch (level) {
@@ -54,101 +57,101 @@ public final class PahoLogger implements org.eclipse.paho.client.mqttv3.logging.
         }
     }
 
-    @Override public void severe(String sourceClass, String sourceMethod, String msg) {
+    @Override public void severe(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         log(SEVERE, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void severe(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void severe(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         log(SEVERE, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void severe(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable thrown) {
+    @Override public void severe(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable thrown) {
         log(SEVERE, sourceClass, sourceMethod, msg, inserts, thrown);
     }
 
-    @Override public void warning(String sourceClass, String sourceMethod, String msg) {
+    @Override public void warning(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         log(WARNING, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void warning(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void warning(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         log(WARNING, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void warning(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable thrown) {
+    @Override public void warning(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable thrown) {
         log(WARNING, sourceClass, sourceMethod, msg, inserts, thrown);
     }
 
-    @Override public void info(String sourceClass, String sourceMethod, String msg) {
+    @Override public void info(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         log(INFO, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void info(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void info(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         log(INFO, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void info(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable thrown) {
+    @Override public void info(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable thrown) {
         log(INFO, sourceClass, sourceMethod, msg, inserts, thrown);
     }
 
-    @Override public void config(String sourceClass, String sourceMethod, String msg) {
+    @Override public void config(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         log(CONFIG, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void config(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void config(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         log(CONFIG, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void config(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable thrown) {
+    @Override public void config(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable thrown) {
         log(CONFIG, sourceClass, sourceMethod, msg, inserts, thrown);
     }
 
-    @Override public void fine(String sourceClass, String sourceMethod, String msg) {
+    @Override public void fine(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         trace(FINE, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void fine(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void fine(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         trace(FINE, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void fine(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable ex) {
+    @Override public void fine(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable ex) {
         trace(FINE, sourceClass, sourceMethod, msg, inserts, ex);
     }
 
-    @Override public void finer(String sourceClass, String sourceMethod, String msg) {
+    @Override public void finer(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         trace(FINER, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void finer(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void finer(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         trace(FINER, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void finer(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable ex) {
+    @Override public void finer(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable ex) {
         trace(FINER, sourceClass, sourceMethod, msg, inserts, ex);
     }
 
-    @Override public void finest(String sourceClass, String sourceMethod, String msg) {
+    @Override public void finest(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg) {
         trace(FINEST, sourceClass, sourceMethod, msg, null, null);
     }
 
-    @Override public void finest(String sourceClass, String sourceMethod, String msg, Object[] inserts) {
+    @Override public void finest(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts) {
         trace(FINEST, sourceClass, sourceMethod, msg, inserts, null);
     }
 
-    @Override public void finest(String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable ex) {
+    @Override public void finest(@Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable ex) {
         trace(FINEST, sourceClass, sourceMethod, msg, inserts, ex);
     }
 
     @Override
-    public void log(int level, String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable thrown) {
+    public void log(int level, @Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable thrown) {
         logToSlf4j(level, sourceClass, sourceMethod, msg, inserts, thrown);
     }
 
     @Override
-    public void trace(int level, String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable ex) {
+    public void trace(int level, @Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable ex) {
         logToSlf4j(level, sourceClass, sourceMethod, msg, inserts, ex);
     }
 
-    private void logToSlf4j(int level, String sourceClass, String sourceMethod, String msg, Object[] inserts, Throwable throwable) {
+    private void logToSlf4j(int level, @Nullable String sourceClass, @Nullable String sourceMethod, @Nullable String msg, @Nullable Object[] inserts, @Nullable Throwable throwable) {
         if (!isLoggable(level)) return;
         StringBuilder message = new StringBuilder();
         if (!Util.isNullOrEmpty(sourceClass)) {
@@ -187,16 +190,16 @@ public final class PahoLogger implements org.eclipse.paho.client.mqttv3.logging.
     }
 
     /**
-     * <p>This method is unused in the built-in JSR47 implementation, and thus is unsed here as well;
+     * <p>This method is unused in the built-in JSR47 implementation, and thus is unused here as well;
      * it is overridden here for completeness.</p>
      *
      * @param msg unused.
      * @param inserts unused.
      * @return {@code null}.
      */
-    @Override public String formatMessage(String msg, Object[] inserts) { return null; }
+    @Override public String formatMessage(@Nullable String msg, @Nullable Object[] inserts) { return null; }
 
-    /** <p>This method is specific to JUL logging, and thus does nothing</p> */
+    /** <p>This method is specific to JUL logging, and thus does nothing.</p> */
     @Override public void dumpTrace() {}
 
 }

--- a/src/main/java/io/auklet/misc/Util.java
+++ b/src/main/java/io/auklet/misc/Util.java
@@ -251,7 +251,7 @@ public final class Util {
      * @throws AukletException if schema validation fails.
      */
     @NonNull public static Json validateJson(@NonNull Json json, @NonNull String clazz) throws AukletException {
-        if (json == null) throw new AukletException("Input is null");
+        if (json == null) throw new AukletException("Input is null.");
         Json schemaValidation = getJsonSchema(clazz).validate(json);
         if (schemaValidation.is("ok", true)) return json;
         List<Json> errors = schemaValidation.at("errors").asJsonList();

--- a/src/main/java/io/auklet/misc/Util.java
+++ b/src/main/java/io/auklet/misc/Util.java
@@ -90,8 +90,9 @@ public final class Util {
      *
      * @param file the file to write. No-op if {@code null}.
      * @param contents the string to write to the file. No-op if {@code null} or empty.
+     * @throws IOException if an I/O error occurs.
      */
-    public static void writeUtf8(@Nullable File file, @Nullable String contents) {
+    public static void writeUtf8(@Nullable File file, @Nullable String contents) throws IOException {
         if (file == null) return;
         if (isNullOrEmpty(contents)) return;
         try {
@@ -106,15 +107,16 @@ public final class Util {
      *
      * @param file the file to write. No-op if {@code null}.
      * @param bytes the bytes to write to the file. No-op if {@code null} or empty.
+     * @throws IOException if an I/O error occurs.
      */
-    public static void write(@Nullable File file, @Nullable byte[] bytes) {
+    public static void write(@Nullable File file, @Nullable byte[] bytes) throws IOException {
         if (file == null) return;
         if (bytes == null || bytes.length == 0) return;
         try (FileOutputStream outputStream = new FileOutputStream(file)) {
             outputStream.write(bytes);
             outputStream.flush();
-        } catch (IOException e) {
-            LOGGER.warn("Could not write file.", e);
+        } catch (SecurityException e) {
+            throw new IOException(e);
         }
     }
 

--- a/src/main/java/io/auklet/platform/AbstractPlatform.java
+++ b/src/main/java/io/auklet/platform/AbstractPlatform.java
@@ -16,9 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-/**
- * <p>Descendants of this class implement platform specific helper functions.</p>
- */
+/** <p>Provides logic common to all platforms.</p> */
 public abstract class AbstractPlatform extends HasAgent implements Platform {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlatform.class);
@@ -57,16 +55,16 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
     }
 
     /**
-     * <p>Determines the possible config directories Auklet can use based on the underlying platform.</p>
+     * <p>Determines the possible config directories that can be used by the agent.</p>
      *
      * @param fromConfig the value from the {@link Config} object, env var and/or JVM sysprop, possibly
      * {@code null}.
-     * @return the list of possible config directories that we are able to use
+     * @return the list of possible config directories that can be used on this platform.
      */
     @NonNull protected abstract List<String> getPossibleConfigDirs(@Nullable String fromConfig);
 
     /**
-     * <p>Checks the directory for write permissions or it attempts to create the directory, or it gives up.</p>
+     * <p>Checks the directory for write permissions, or attempts to create the directory, or gives up.</p>
      *
      * @param possibleConfigDir the directory that needs to be checked for write permissions.
      * @return possibly {@code null}, in which case the Auklet agent must throw an exception during

--- a/src/main/java/io/auklet/platform/AndroidPlatform.java
+++ b/src/main/java/io/auklet/platform/AndroidPlatform.java
@@ -45,7 +45,7 @@ public final class AndroidPlatform extends AbstractPlatform {
      * <p>Returns the directory used by the agent on Android to store config files.</p>
      *
      * @param fromConfig unused.
-     * @return a list with exactly one element: {@code context.getFilesDir().getPath() + "/aukletFiles"}.
+     * @return a list with exactly one element: {@code context.getFilesDir().getPath() + "/.auklet"}.
      */
     @Override public List<String> getPossibleConfigDirs(@Nullable String fromConfig) {
         return Collections.singletonList(this.context.getFilesDir().getPath() + "/.auklet");

--- a/src/main/java/io/auklet/platform/AndroidPlatform.java
+++ b/src/main/java/io/auklet/platform/AndroidPlatform.java
@@ -1,11 +1,11 @@
 package io.auklet.platform;
 
 import android.content.Context;
+import android.os.Build;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.auklet.Auklet;
 import io.auklet.AukletException;
-import io.auklet.Config;
 import io.auklet.platform.metrics.AndroidMetrics;
 import net.jcip.annotations.Immutable;
 import org.msgpack.core.MessagePacker;
@@ -30,6 +30,7 @@ public final class AndroidPlatform extends AbstractPlatform {
      */
     public AndroidPlatform(@NonNull Object context) throws AukletException {
         if (!(context instanceof Context)) throw new AukletException("Android platform was given a non-Context object.");
+        if (Build.VERSION.SDK_INT < 16) throw new AukletException("Unsupported Android API level: " + Build.VERSION.SDK_INT);
         this.context = (Context) context;
         this.metrics = new AndroidMetrics(this.context);
     }

--- a/src/main/java/io/auklet/platform/AndroidPlatform.java
+++ b/src/main/java/io/auklet/platform/AndroidPlatform.java
@@ -7,6 +7,7 @@ import io.auklet.Auklet;
 import io.auklet.AukletException;
 import io.auklet.Config;
 import io.auklet.platform.metrics.AndroidMetrics;
+import net.jcip.annotations.Immutable;
 import org.msgpack.core.MessagePacker;
 
 import java.io.IOException;
@@ -14,22 +15,20 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/**
- * <p>This class contain Android specific helper functions.</p>
- */
-public class AndroidPlatform extends AbstractPlatform {
+/** <p>Platform methods specific to Android.</p> */
+@Immutable
+public final class AndroidPlatform extends AbstractPlatform {
 
     private final Context context;
     private final AndroidMetrics metrics;
 
     /**
-     * <p>Constructor that checks to see if the Android context is {@code null} and will create the
-     * Android metrics object.</p>
+     * <p>Constructor.</p>
      *
      * @param context the Android context.
      * @throws AukletException if context is {@code null}.
      */
-    public AndroidPlatform(Object context) throws AukletException {
+    public AndroidPlatform(@NonNull Object context) throws AukletException {
         if (!(context instanceof Context)) throw new AukletException("Android platform was given a non-Context object.");
         this.context = (Context) context;
         this.metrics = new AndroidMetrics(this.context);
@@ -37,24 +36,22 @@ public class AndroidPlatform extends AbstractPlatform {
 
     @Override public void start(@NonNull Auklet agent) throws AukletException {
         super.start(agent);
-
         Runnable cpuUsage = metrics.calculateCpuUsage();
-        if(cpuUsage != null) agent.scheduleRepeatingTask(cpuUsage, 0L, 1L, TimeUnit.SECONDS);
+        if (cpuUsage != null) agent.scheduleRepeatingTask(cpuUsage, 0L, 1L, TimeUnit.SECONDS);
     }
 
     /**
-     * <p>Determines the possible config directories Auklet can use based on the underlying platform.</p>
+     * <p>Returns the directory used by the agent on Android to store config files.</p>
      *
-     * @param fromConfig the value from the {@link Config} object, env var and/or JVM sysprop, possibly
-     * {@code null}. Unused in this implementation
-     * @return the list of possible config directories that we are able to use. This method will return
-     * exactly 1 element
+     * @param fromConfig unused.
+     * @return a list with exactly one element: {@code context.getFilesDir().getPath() + "/aukletFiles"}.
      */
     @Override public List<String> getPossibleConfigDirs(@Nullable String fromConfig) {
         return Collections.singletonList(this.context.getFilesDir().getPath() + "/aukletFiles");
     }
 
-    @Override public void addSystemMetrics(@NonNull MessagePacker msgpack) throws IOException {
+    @Override public void addSystemMetrics(@NonNull MessagePacker msgpack) throws AukletException, IOException {
+        if (msgpack == null) throw new AukletException("msgpack is null.");
         msgpack.packString("memoryUsage").packDouble(metrics.getMemoryUsage());
         msgpack.packString("cpuUsage").packDouble(metrics.getCpuUsage());
     }

--- a/src/main/java/io/auklet/platform/JavaPlatform.java
+++ b/src/main/java/io/auklet/platform/JavaPlatform.java
@@ -13,10 +13,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/**
- * <p>This class contain Java specific helper functions.</p>
- */
 public class JavaPlatform extends AbstractPlatform {
+/** <p>Platform methods specific to Java SE (and variants).</p> */
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaPlatform.class);
 

--- a/src/main/java/io/auklet/platform/JavaPlatform.java
+++ b/src/main/java/io/auklet/platform/JavaPlatform.java
@@ -2,8 +2,10 @@ package io.auklet.platform;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.auklet.AukletException;
 import io.auklet.misc.Util;
 import io.auklet.platform.metrics.OSMX;
+import net.jcip.annotations.Immutable;
 import org.msgpack.core.MessagePacker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,8 +15,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class JavaPlatform extends AbstractPlatform {
 /** <p>Platform methods specific to Java SE (and variants).</p> */
+@Immutable
+public final class JavaPlatform extends AbstractPlatform {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JavaPlatform.class);
 
@@ -37,7 +40,8 @@ public class JavaPlatform extends AbstractPlatform {
         return filteredConfigDirs;
     }
 
-    @Override public void addSystemMetrics(@NonNull MessagePacker msgpack) throws IOException {
+    @Override public void addSystemMetrics(@NonNull MessagePacker msgpack) throws AukletException, IOException {
+        if (msgpack == null) throw new AukletException("msgpack is null.");
         // Calculate memory usage.
         double memUsage;
         long freeMem = OSMX.BEAN.getFreePhysicalMemorySize();

--- a/src/main/java/io/auklet/platform/Platform.java
+++ b/src/main/java/io/auklet/platform/Platform.java
@@ -10,12 +10,14 @@ import java.io.File;
 import java.io.IOException;
 
 /**
- * <p>The platform in which Auklet will be running on.</p>
+ * <p>The platform on which Auklet is running. After initialization, the agent has a reference to exactly
+ * one instance of this interface that provides behavior appropriate to the underlying platform (Java SE,
+ * Android, etc.)</p>
  */
 public interface Platform {
 
     /**
-     * <p>Adds JVM memory and cpu usage current position in the given MessagePacker as a map object.</p>
+     * <p>Adds OS memory/CPU usage metrics to the given MessagePack as map entries.</p>
      *
      * @param msgpack the msgpack that will be sent to auklet
      * @throws IOException if the MessagePacker is {@code null}.

--- a/src/main/java/io/auklet/platform/Platform.java
+++ b/src/main/java/io/auklet/platform/Platform.java
@@ -3,6 +3,7 @@ package io.auklet.platform;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.auklet.AukletException;
 import io.auklet.Config;
 import org.msgpack.core.MessagePacker;
 
@@ -19,10 +20,11 @@ public interface Platform {
     /**
      * <p>Adds OS memory/CPU usage metrics to the given MessagePack as map entries.</p>
      *
-     * @param msgpack the msgpack that will be sent to auklet
-     * @throws IOException if the MessagePacker is {@code null}.
+     * @param msgpack the MessagePack to which the metrics will be added.
+     * @throws AukletException if the input is {@code null}.
+     * @throws IOException if an error occurs while adding the metrics.
      */
-    void addSystemMetrics(@NonNull MessagePacker msgpack) throws IOException;
+    void addSystemMetrics(@NonNull MessagePacker msgpack) throws AukletException, IOException;
 
     /**
      * <p>Returns the directory the Auklet agent will use to store its configuration files. This method

--- a/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
+++ b/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
@@ -85,14 +85,13 @@ public final class AndroidMetrics {
      * @return a non-negative value.
      */
     public double getMemoryUsage() {
-        // memInfo.totalMem needs API 16+
         return memInfo.availMem / (double) memInfo.totalMem * 100.0;
     }
 
     /**
      * <p>Returns the CPU usage of the OS on which this agent is running.</p>
      *
-     * @return a non-negative value.
+     * @return a non-negative value. If running on Android 8 or lower, will always be zero.
      */
     public float getCpuUsage() {
         synchronized (lock) {

--- a/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
+++ b/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 public final class AndroidMetrics {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AndroidMetrics.class);
-    private final ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+    private final ActivityManager activityManager;
 
     private final Object lock = new Object();
     private long total = 0L;
@@ -37,7 +37,7 @@ public final class AndroidMetrics {
     private float cpuUsage = 0;
 
     /**
-     * <p>Creates the {@link ActivityManager} which is used to collect memory usage.</p>
+     * <p>Constructor.</p>
      *
      * @param context the Android context.
      * @throws AukletException if context is {@code null}.
@@ -45,8 +45,7 @@ public final class AndroidMetrics {
     public AndroidMetrics(@NonNull Context context) throws AukletException {
         if (context == null) throw new AukletException("Android context is null.");
         if (Build.VERSION.SDK_INT >= 26) LOGGER.warn("Running on Android 8 or higher; system CPU stats will not be available.");
-        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
-        manager.getMemoryInfo(memInfo);
+        this.activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
     }
 
     @Nullable public Runnable calculateCpuUsage() {
@@ -85,6 +84,8 @@ public final class AndroidMetrics {
      * @return a non-negative value.
      */
     public double getMemoryUsage() {
+        ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+        activityManager.getMemoryInfo(memInfo);
         return memInfo.availMem / (double) memInfo.totalMem * 100.0;
     }
 

--- a/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
+++ b/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
@@ -48,6 +48,15 @@ public final class AndroidMetrics {
         this.activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
     }
 
+    /**
+     * <p>Returns a runnable task that periodically gets system CPU usage from the
+     * Android device on which the agent is running. Android has no APIs available to
+     * obtain this information, so we have to use a background thread to read the
+     * {@code /proc/stat} file.</p>
+     *
+     * @return {@code null} iff running on Android 8 or higher, in which case no
+     * background task will be executed.
+     */
     @Nullable public Runnable calculateCpuUsage() {
         if (Build.VERSION.SDK_INT >= 26) return null;
         return new Runnable() {
@@ -92,7 +101,7 @@ public final class AndroidMetrics {
     /**
      * <p>Returns the CPU usage of the OS on which this agent is running.</p>
      *
-     * @return a non-negative value. If running on Android 8 or lower, will always be zero.
+     * @return a non-negative value. If running on Android 8 or higher, will always be zero.
      */
     public float getCpuUsage() {
         synchronized (lock) {

--- a/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
+++ b/src/main/java/io/auklet/platform/metrics/AndroidMetrics.java
@@ -6,6 +6,7 @@ import android.os.Build;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.auklet.AukletException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,85 +15,80 @@ import java.io.FileReader;
 import java.io.IOException;
 
 /**
- * <p>This class handles retrieving the memory and cpu usage for Android devices.</p>
+ * <p>This class handles retrieving memory and CPU usage for Android devices.</p>
  *
- * <p>cpu usage can only be retrieved for devices running on Android 7 or older. If your device is running on
- * something newer than Android 7, then the cpu usage will return 0.</p>
+ * <p>CPU usage can only be retrieved on Android 7 or lower. When running on Android 8+,
+ * this class will always report {@code 0} for CPU usage.</p>
  */
 public final class AndroidMetrics {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AndroidMetrics.class);
-    private ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
-    private ActivityManager manager;
+    private final ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
 
-    private long total;
-    private long totalBefore;
-    private long totalDiff;
-    private long work;
-    private long workBefore;
-    private long workDiff;
+    private long total = 0L;
+    private long totalBefore = 0L;
+    private long totalDiff = 0L;
+    private long work = 0L;
+    private long workBefore = 0L;
+    private long workDiff = 0L;
     private float cpuUsage = 0;
 
     /**
-     * <p>Constructor that creates the Activity Manager in order to be able to calculate the memory used in android.
-     * Also initializes global variables used for calculating cpu usage</p>
+     * <p>Creates the {@link ActivityManager} which is used to collect memory usage.</p>
      *
      * @param context the Android context.
+     * @throws AukletException if context is {@code null}.
      */
-    public AndroidMetrics(Context context) {
-        LOGGER.debug("We are unable to attain cpu data on devices running Android 8+");
-        manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+    public AndroidMetrics(@NonNull Context context) throws AukletException {
+        if (context == null) throw new AukletException("Android context is null.");
+        if (Build.VERSION.SDK_INT >= 26) LOGGER.warn("Running on Android 8 or higher; system CPU stats will not be available.");
+        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
         manager.getMemoryInfo(memInfo);
-        total = totalBefore = totalDiff = work = workBefore = workDiff = 0L;
     }
 
     @Nullable public Runnable calculateCpuUsage() {
-        // On Android 8+, Google has restricted access to the proc files
-        if (Build.VERSION.SDK_INT < 26) {
-            return new Runnable() {
-                @Override
-                public void run() {
-                    try (BufferedReader reader = new BufferedReader(new FileReader("/proc/stat"))) {
-                        // Obtain current CPU Load
-                        String[] s = reader.readLine().split("[ ]+", 9);
-                        work = Long.parseLong(s[1]) + Long.parseLong(s[2]) + Long.parseLong(s[3]);
-                        total = work + Long.parseLong(s[4]) + Long.parseLong(s[5]) +
-                                Long.parseLong(s[6]) + Long.parseLong(s[7]);
-                    } catch (IOException e) {
-                        LOGGER.error("Unable to obtain cpu usage", e);
-                        return;
-                    }
-
+        if (Build.VERSION.SDK_INT >= 26) return null;
+        return new Runnable() {
+            @Override
+            public void run() {
+                try (BufferedReader reader = new BufferedReader(new FileReader("/proc/stat"))) {
+                    // Obtain current CPU Load
+                    String[] s = reader.readLine().split("[ ]+", 9);
+                    work = Long.parseLong(s[1]) + Long.parseLong(s[2]) + Long.parseLong(s[3]);
+                    total = work + Long.parseLong(s[4]) + Long.parseLong(s[5]) +
+                            Long.parseLong(s[6]) + Long.parseLong(s[7]);
                     // Calculate CPU Percentage
                     if (totalBefore != 0) {
                         workDiff = work - workBefore;
                         totalDiff = total - totalBefore;
                         cpuUsage = workDiff * 100 / (float) totalDiff;
                     }
-
                     totalBefore = total;
                     workBefore = work;
+                } catch (IOException e) {
+                    LOGGER.warn("Unable to obtain CPU usage", e);
+                    return;
                 }
-            };
-        }
-
-        return null;
+            }
+        };
     }
 
-    /** <p>Returns the memory Uuage for this Android device.</p>
+    /**
+     * <p>Returns the memory usage of the OS on which this agent is running.</p>
      *
-     * @return the memory usage for android.
+     * @return a non-negative value.
      */
-    @NonNull public double getMemoryUsage() {
+    public double getMemoryUsage() {
         // memInfo.totalMem needs API 16+
         return memInfo.availMem / (double) memInfo.totalMem * 100.0;
     }
 
-    /** <p>Returns the cpu usage for this Android device. Return 0 if Android 8+.</p>
+    /**
+     * <p>Returns the CPU usage of the OS on which this agent is running.</p>
      *
-     * @return the cpu usage for android.
+     * @return a non-negative value.
      */
-    @NonNull public float getCpuUsage() {
+    public float getCpuUsage() {
         return cpuUsage;
     }
 

--- a/src/main/java/io/auklet/sink/AbstractSink.java
+++ b/src/main/java/io/auklet/sink/AbstractSink.java
@@ -112,7 +112,7 @@ public abstract class AbstractSink extends HasAgent implements Sink {
     private void addSystemMetrics() throws AukletException {
         try {
             this.msgpack.packMapHeader(4);
-            getAgent().getPlatform().addSystemMetrics(this.msgpack);
+            this.getAgent().getPlatform().addSystemMetrics(this.msgpack);
             // Add other system metrics.
             this.msgpack.packString("outboundNetwork").packDouble(0);
             this.msgpack.packString("inboundNetwork").packDouble(0);

--- a/src/main/java/io/auklet/sink/AbstractSink.java
+++ b/src/main/java/io/auklet/sink/AbstractSink.java
@@ -105,9 +105,8 @@ public abstract class AbstractSink extends HasAgent implements Sink {
     }
 
     /**
-     * <p>Adds JVM system metrics to the current position in the given MessagePacker as a map object.</p>
+     * <p>Adds system metrics to the current position in the given MessagePacker as a map object.</p>
      *
-     * @throws IllegalArgumentException if the MessagePacker is {@code null}.
      * @throws AukletException if an error occurs while assembling the message.
      */
     private void addSystemMetrics() throws AukletException {

--- a/src/main/java/io/auklet/sink/SerialPortSink.java
+++ b/src/main/java/io/auklet/sink/SerialPortSink.java
@@ -79,7 +79,7 @@ public final class SerialPortSink extends AbstractSink {
                 this.getAgent().getUsageMonitor().addMoreData(size);
             }
         } catch (IOException e) {
-            throw new AukletException("Could not write data to serial port", e);
+            throw new AukletException("Could not write data to serial port.", e);
         }
     }
 


### PR DESCRIPTION
- Cleanup Javadocs, documentation of thread safety/nullable handling, and code style/formatting.
- Change how some exceptions were being propagated internally.
- Fix thread safety for `DataUsageTracker` and `AndroidMetrics`.
- Cause agent init to fail on Android if API level is less than 16.
- Fix memory usage retrieval in `AndroidMetrics`.