### PR TITLE
Support Java 7 more strictly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
             TZ: "/usr/share/zoneinfo/America/Detroit"
         working_directory: ~/app
         docker:
-            - image: circleci/openjdk:9.0.4-jdk-sid-node-browsers
+            - image: circleci/openjdk:11.0.1-jdk-sid-node-browsers
         steps:
 
             ##

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             - run:
                 name: Run Gradle Tests
                 command: |
-                  TERM=dumb ./gradlew clean test --info
+                  TERM=dumb ./gradlew clean test
             - run:
                 name: Run Whitesource
                 command: |

--- a/README.md
+++ b/README.md
@@ -3,29 +3,89 @@
 # Auklet for Java
 [![Maintainability](https://api.codeclimate.com/v1/badges/e1ced62442c7cf49d58a/maintainability)](https://codeclimate.com/github/aukletio/Auklet-Agent-Java/maintainability)
 
-This is the Java agent for Auklet, officially supporting Java 7+.
+This is the Java agent for Auklet, officially supporting Java 7+ and Android Jelly Bean or higher (4.1.x+, API level 16+).
 
 # Features
 
 * Automatic report of unhandled exceptions.
-* Location, and system metrics identification for all issues.
+* Location and system metrics identification for all issues.
 
 
 # Quickstart
+The Auklet Java agent is deployed to [JCenter](https://bintray.com/bintray/jcenter).
 
-* Download the agent JAR using Maven or Gradle from https://bintray.com/aukletio/agent-java/auklet-agent-java.
-* Configure your app ID and API key using the environment variables `AUKLET_APP_ID` and `AUKLET_API_KEY` or the
-JVM system properties `auklet.app.id` and `auklet.api.key`.
-* The agent needs a dedicated folder to create and store its configuration files. The agent will create these files 
-on startup if they do not exist, or will use files that are already available on disk.
-* If you are running the agent on an Android device, you will need to pass in your Android Context to the Config using
-`new Config().setAndroidContext(getApplicationContext())`. You will also need to add
-`<uses-permission android:name="android.permission.INTERNET" />` to your Android Manifest.
+## Maven
+```
+<dependency>
+  <groupId>io.auklet</groupId>
+  <artifactId>auklet-agent-java</artifactId>
+  <version>...</version>
+</dependency>
+```
 
-# Authorization
+## Gradle
+`compile 'io.auklet:auklet-agent-java:<version>'`
 
-To authorize your application you need to provide both an API key and app ID.
-These values are available in the connection settings of your application as well as during initial setup.
+## Configuration/Authorization
+To authorize your application you need to provide both an API key and app ID. These values are available in the connection settings of your application as well as during initial setup.
+
+Unless you use the `Config` object to manually set your Auklet credentials, you will need to set one of the following on the JVM where you are running Auklet:
+* The environment variables `AUKLET_APP_ID` and `AUKLET_API_KEY`
+* JVM system properties `auklet.app.id` and `auklet.api.key`
+
+On Android, you will need to add
+`<uses-permission android:name="android.permission.INTERNET" />` to your manifest.
+
+## Code
+
+### Java
+```
+// Use this to start the agent using env vars/JVM sysprops...
+Auklet.init()
+// ...or use this to configure manually...
+Auklet.init(new Auklet.Config()
+    .setAppId("...")
+    .setApiKey("...")
+    // ...set other options here
+)
+// ...or no code at all (see below).
+
+// Explicitly send an exception to Auklet.
+Auklet.send(new Exception())
+```
+
+#### Auto-Start (Java only)
+Set the environment variable `AUKLET_AUTO_START` or the JVM system property `auklet.auto.start` to `true` to have the agent start alongside the JVM. In this configuration, the agent will only send to Auklet exceptions that are not caught within a thread or by a thread handler. If you want to explicitly catch and report some exceptions to Auklet, do not use this method.
+
+### Android
+```
+// Use this to start the agent using env vars/JVM sysprops...
+Auklet.init(new Auklet.Config().setAndroidContext(getApplicationContext()))
+// ...or use this to configure manually.
+Auklet.init(new Auklet.Config()
+    .setAndroidContext(getApplicationContext())
+    .setAppId("...")
+    .setApiKey("...")
+    // ...set other options here
+)
+
+// Explicitly send an exception to Auklet.
+Auklet.send(new Exception())
+```
+
+# Compiling/Running Locally
+Auklet for Java uses Gradle 4 and requires Java 7+ to compile (Java 9+ recommended).
+
+```
+git clone git@github.com:aukletio/Auklet-Agent-Java.git
+cd Auklet-Agent-Java
+# This stores the Auklet agent in your local Maven repository with artifact version "local-build", which you can use per the instructions above.
+./gradlew publishToMavenLocal
+```
+
+When compiling on Java 7, you will see warnings related to dependencies compiled for newer versions of Java; these warnings can be ignored.
+
+When compiling on Java 8, use this syntax fix cross-compilation warnings (requires installing JDK 7): `JDK7_HOME=/path/to/java7/home ./gradlew publishToMavenLocal`
 
 # Questions? Problems? Ideas?
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Auklet.init(new Auklet.Config()
 Auklet.send(new Exception())
 ```
 
+#### Note Regarding TLS Support
+The auklet.io data pipeline uses TLS 1.2. According to [Android docs](https://developer.android.com/reference/javax/net/ssl/SSLSocket#protocols), TLS 1.2 is enabled by default starting with API level 20 (Android version 4.4W). If your application supports API levels 16 through 19, you may need to do additional work to ensure that TLS 1.2 is available.
+
+If TLS 1.2 is not available on a device, the Auklet agent will fail to initialize and will log relevant messages to SLF4J, but this will not interrupt your application. Notably, since `Auklet.init()` never throws any exceptions, you will not be notified by the agent if it fails to initialize for this reason, so you should take care to ensure TLS 1.2 is available prior to invoking `Auklet.init()`.
+
+You may find [this post](https://medium.com/tech-quizlet/working-with-tls-1-2-on-android-4-4-and-lower-f4f5205629a) relevant in adding TLS 1.2 compatibility for devices on API levels 16 through 19.
+
 # Compiling/Running Locally
 Auklet for Java uses Gradle 4 and requires Java 7+ to compile (Java 9+ recommended).
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,28 @@ allprojects {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+            // When compiling with JDK 7, warnings are generated because SpotBugs Annotations
+            // and purejavacomm are compiled for Java 8. These warnings seem to be silenceable
+            // only with "-Xlint:none", but Oracle docs are not clear on what other warnings
+            // are silenced by doing this, so don't try to silence those warnings.
+
+            // On JDK 8, when env var JDK7_HOME is set (should only be set when Gradle itself is not
+            // run with JDK 7, e.g. in CircleCI), use it as the bootstrap classpath to eliminate
+            // compilation warnings/enforce Java 7 syntax.
+            def jdk7Home = System.getenv("JDK7_HOME")
+            if (JavaVersion.current().isJava8() && jdk7Home) {
+                options.bootstrapClasspath = files(
+                        "${jdk7Home}/jre/lib/resources.jar",
+                        "${jdk7Home}/jre/lib/rt.jar",
+                        "${jdk7Home}/jre/lib/sunrsasign.jar",
+                        "${jdk7Home}/jre/lib/jsse.jar",
+                        "${jdk7Home}/jre/lib/jce.jar",
+                        "${jdk7Home}/jre/lib/charsets.jar",
+                        "${jdk7Home}/jre/lib/rhino.jar",
+                        "${jdk7Home}/jre/lib/jfr.jar",
+                        "${jdk7Home}/jre/classes"
+                )
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,13 @@ dependencies {
     compile "org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.0"
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "com.github.stephenc.jcip:jcip-annotations:1.0-1"
-    // End-users never need to re-include this library in their list of dependencies, and those
-    // that do so may run into legal issues if they distribute it alongside an Oracle JRE/JDK.
-    // See https://stackoverflow.com/a/36198568 for details.
+    // End-users never need to re-include SpotBugs Annotations in their list of dependencies,
+    // and those that do so may run into legal issues if they distribute it alongside an
+    // Oracle JRE/JDK. See https://stackoverflow.com/a/36198568 for details.
+    // Also, SpotBugs Annotations requires Java 8.
     compileOnly "com.github.spotbugs:spotbugs-annotations:3.1.10"
+    // purejavacomm requires Java 8. If you are using purejavacomm, you should also include
+    // sysout-over-slf4j so that purejavacomm's logging uses SLF4J.
     compileOnly "com.github.purejavacomm:purejavacomm:1.0.1.RELEASE"
     compileOnly "uk.org.lidalia:sysout-over-slf4j:1.0.2"
     compileOnly("com.google.android:android:4.1.1.4") {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-// Plugins
 plugins {
     id 'idea'
     id 'java'
@@ -8,16 +7,13 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.4'
 }
 
-// Project info
 group "${theGroup}"
 version "${theVersion}"
 description = 'Official Auklet SDK for Java and other JVM languages.'
 
-// Java version
 sourceCompatibility = 7
 targetCompatibility = 7
 
-// Dependencies
 repositories {
     jcenter()
     google()
@@ -48,7 +44,6 @@ dependencies {
     testCompile "org.slf4j:slf4j-simple:1.7.25"
 }
 
-// Compilation configuration
 allprojects {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
@@ -78,7 +73,6 @@ allprojects {
         }
     }
 }
-
 // Module export (compile-time Java 9+)
 if (JavaVersion.current().isJava9Compatible()) {
     sourceSets {
@@ -107,12 +101,10 @@ if (JavaVersion.current().isJava9Compatible()) {
     }
 }
 
-// Test configuration
 test {
     testLogging.showStandardStreams = true
 }
 
-// Javadoc configuration
 javadoc {
     source = sourceSets.main.allJava
     classpath = configurations.compileClasspath
@@ -121,7 +113,6 @@ javadoc {
     }
 }
 
-// Packaging configurations
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
     from sourceSets.main.allSource
@@ -145,7 +136,6 @@ jar {
     }
 }
 
-// Deployment configurations
 def pomConfig = {
     licenses {
         license {

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,9 @@ test {
 javadoc {
     source = sourceSets.main.allJava
     classpath = configurations.compileClasspath
+    if (JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
 }
 
 // Packaging configurations

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     id 'idea'
     id 'java'
-    id 'com.github.gmazzo.buildconfig' version '1.3.6'
+    id 'de.fuerstenau.buildconfig' version '1.1.8'
     id 'maven'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
@@ -12,19 +12,6 @@ plugins {
 group "${theGroup}"
 version "${theVersion}"
 description = 'Official Auklet SDK for Java and other JVM languages.'
-buildConfig {
-    buildConfigField('String', 'AGENT_VERSION', "\"${version}\"")
-}
-generateBuildConfig {
-    addGeneratedAnnotation = false
-}
-
-// IDE configuration
-idea {
-    module {
-        generatedSourceDirs += file('build/generated/source/buildConfig/main')
-    }
-}
 
 // Java version
 sourceCompatibility = 7

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 rootProject.name = theName
-include 'agent'
+enableFeaturePreview('STABLE_PUBLISHING')

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -68,7 +68,7 @@ public final class Auklet {
         // Extract Auklet agent version from the BuildConfig class.
         String version = "unknown";
         try {
-            version = BuildConfig.AGENT_VERSION;
+            version = BuildConfig.VERSION;
         } catch (RuntimeException | NoClassDefFoundError e) {
             LOGGER.warn("Could not obtain Auklet agent version from manifest.", e);
         }

--- a/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
+++ b/src/main/java/io/auklet/misc/AukletDaemonExecutor.java
@@ -71,11 +71,7 @@ public final class AukletDaemonExecutor extends ScheduledThreadPoolExecutor {
         return r instanceof CancelSilentlyRunnable ? new CancelSilentlyRSF<>(task) : task;
     }
 
-    /**
-     * A {@link Runnable} that the {@link AukletDaemonExecutor} will not log if it is cancelled.
-     *
-     * {@inheritDoc}
-     */
+    /** A {@link Runnable} that the {@link AukletDaemonExecutor} will not log if it is cancelled. */
     public abstract static class CancelSilentlyRunnable implements Runnable {}
 
     /*


### PR DESCRIPTION
- Switch build config plugins so we can compile with Gradle 4/Java 7
- Add support for fixing cross-compilation warnings when using Java 8
- Fix all other fixable Gradle warnings
- Use Java 11 in CI
- Update README