### PR TITLE
Fix TLS 1.2 on Android API levels 16 thru 19

### DIFF
--- a/src/main/java/io/auklet/misc/Tls12SocketFactory.java
+++ b/src/main/java/io/auklet/misc/Tls12SocketFactory.java
@@ -1,0 +1,83 @@
+package io.auklet.misc;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.auklet.AukletException;
+import net.jcip.annotations.NotThreadSafe;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * <p>A custom SSL socket factory that only supports TLS 1.2. This class adds compatibility for SSL connections
+ * on Android versions less than 4.4W.</p>
+ *
+ * <p>Derived from https://gist.githubusercontent.com/fkrauthan/ac8624466a4dee4fd02f/raw/309efc30e31c96a932ab9d19bf4d73b286b00573/TLSSocketFactory.java.</p>
+ *
+ * @see <a href="https://developer.android.com/reference/javax/net/ssl/SSLSocket.html">SSLSocket docs for Android</a>
+ */
+@NotThreadSafe
+public final class Tls12SocketFactory extends SSLSocketFactory {
+
+    private final SSLSocketFactory delegateFactory;
+
+    /**
+     * <p>Constructor that uses the provided SSL context.</p>
+     *
+     * @param context if {@code null}, a default SSL context will be used.
+     * @throws AukletException if the context cannot be created, or if the socket factory cannot be retrieved.
+     */
+    public Tls12SocketFactory(@Nullable SSLContext context) throws AukletException {
+        try {
+            if (context == null) {
+                context = SSLContext.getInstance("TLS");
+                context.init(null, null, null);
+            }
+            delegateFactory = context.getSocketFactory();
+        } catch (KeyManagementException | NoSuchAlgorithmException | IllegalStateException e) {
+            throw new AukletException("Could not initialize SSL socket factory.", e);
+        }
+    }
+
+    @Override public String[] getDefaultCipherSuites() {
+        return delegateFactory.getDefaultCipherSuites();
+    }
+
+    @Override public String[] getSupportedCipherSuites() {
+        return delegateFactory.getSupportedCipherSuites();
+    }
+
+    @Override public Socket createSocket() throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket());
+    }
+
+    @Override public Socket createSocket(@NonNull Socket s, @Nullable String host, int port, boolean autoClose) throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override public Socket createSocket(@Nullable String host, int port) throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket(host, port));
+    }
+
+    @Override public Socket createSocket(@Nullable String host, int port, @Nullable InetAddress localHost, int localPort) throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override public Socket createSocket(@NonNull InetAddress host, int port) throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket(host, port));
+    }
+
+    @Override public Socket createSocket(@NonNull InetAddress address, int port, @Nullable InetAddress localAddress, int localPort) throws IOException {
+        return setSocketOnlyTls12(delegateFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket setSocketOnlyTls12(@Nullable Socket socket) {
+        if (socket instanceof SSLSocket) ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
+        return socket;
+    }
+
+}

--- a/src/main/java/io/auklet/platform/AndroidPlatform.java
+++ b/src/main/java/io/auklet/platform/AndroidPlatform.java
@@ -9,6 +9,8 @@ import io.auklet.AukletException;
 import io.auklet.platform.metrics.AndroidMetrics;
 import net.jcip.annotations.Immutable;
 import org.msgpack.core.MessagePacker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -19,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 @Immutable
 public final class AndroidPlatform extends AbstractPlatform {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AndroidPlatform.class);
     private final Context context;
     private final AndroidMetrics metrics;
 
@@ -31,6 +34,7 @@ public final class AndroidPlatform extends AbstractPlatform {
     public AndroidPlatform(@NonNull Object context) throws AukletException {
         if (!(context instanceof Context)) throw new AukletException("Android platform was given a non-Context object.");
         if (Build.VERSION.SDK_INT < 16) throw new AukletException("Unsupported Android API level: " + Build.VERSION.SDK_INT);
+        if (Build.VERSION.SDK_INT < 20) LOGGER.warn("Android API level {} does not have TLS 1.2 enabled by default. Agent may not init or function correctly without an update to the Android security provider.", Build.VERSION.SDK_INT);
         this.context = (Context) context;
         this.metrics = new AndroidMetrics(this.context);
     }

--- a/src/main/java/io/auklet/sink/AukletIoSink.java
+++ b/src/main/java/io/auklet/sink/AukletIoSink.java
@@ -5,6 +5,7 @@ import io.auklet.Auklet;
 import io.auklet.AukletException;
 import io.auklet.config.AukletIoBrokers;
 import io.auklet.config.AukletIoCert;
+import io.auklet.misc.Tls12SocketFactory;
 import io.auklet.misc.Util;
 import io.auklet.misc.AukletDaemonExecutor;
 import net.jcip.annotations.ThreadSafe;
@@ -195,7 +196,7 @@ public final class AukletIoSink extends AbstractSink {
             tmf.init(ca);
             SSLContext context = SSLContext.getInstance("TLSv1.2");
             context.init(null, tmf.getTrustManagers(), null);
-            return context.getSocketFactory();
+            return new Tls12SocketFactory(context);
         } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException | KeyManagementException e) {
             throw new AukletException("Error while setting up MQTT SSL socket factory.", e);
         }


### PR DESCRIPTION
MQTT was broken on Android API level 16 because TLSv1.2 is not enabled by default for SSL sockets in that version of Android. Our connection to the Auklet API is not impacted by this because OkHttp handles this problem transparently.

This PR adds a socket factory for MQTT that only returns TLSv1.2-enabled sockets, and logs a warning for the affected API levels in case this workaround somehow doesn't work on particular devices. (Other than the end user updating the Android security provider via Google Play Services, this PR is the only workaround we can make.)