### PR TITLE
Make default SSL context use TLS 1.2

### DIFF
--- a/src/main/java/io/auklet/misc/Tls12SocketFactory.java
+++ b/src/main/java/io/auklet/misc/Tls12SocketFactory.java
@@ -76,6 +76,7 @@ public final class Tls12SocketFactory extends SSLSocketFactory {
     }
 
     private Socket setSocketOnlyTls12(@Nullable Socket socket) {
+        if (socket == null) throw new IllegalArgumentException("Socket is null.");
         if (socket instanceof SSLSocket) ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
         return socket;
     }

--- a/src/main/java/io/auklet/misc/Tls12SocketFactory.java
+++ b/src/main/java/io/auklet/misc/Tls12SocketFactory.java
@@ -34,7 +34,7 @@ public final class Tls12SocketFactory extends SSLSocketFactory {
     public Tls12SocketFactory(@Nullable SSLContext context) throws AukletException {
         try {
             if (context == null) {
-                context = SSLContext.getInstance("TLS");
+                context = SSLContext.getInstance("TLSv1.2");
                 context.init(null, null, null);
             }
             delegateFactory = context.getSocketFactory();

--- a/src/main/java/io/auklet/misc/Tls12SocketFactory.java
+++ b/src/main/java/io/auklet/misc/Tls12SocketFactory.java
@@ -1,5 +1,6 @@
 package io.auklet.misc;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.auklet.AukletException;
@@ -52,30 +53,30 @@ public final class Tls12SocketFactory extends SSLSocketFactory {
     }
 
     @Override public Socket createSocket() throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket());
+        return tls12Only(delegateFactory.createSocket());
     }
 
     @Override public Socket createSocket(@NonNull Socket s, @Nullable String host, int port, boolean autoClose) throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket(s, host, port, autoClose));
+        return tls12Only(delegateFactory.createSocket(s, host, port, autoClose));
     }
 
     @Override public Socket createSocket(@Nullable String host, int port) throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket(host, port));
+        return tls12Only(delegateFactory.createSocket(host, port));
     }
 
     @Override public Socket createSocket(@Nullable String host, int port, @Nullable InetAddress localHost, int localPort) throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket(host, port, localHost, localPort));
+        return tls12Only(delegateFactory.createSocket(host, port, localHost, localPort));
     }
 
     @Override public Socket createSocket(@NonNull InetAddress host, int port) throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket(host, port));
+        return tls12Only(delegateFactory.createSocket(host, port));
     }
 
     @Override public Socket createSocket(@NonNull InetAddress address, int port, @Nullable InetAddress localAddress, int localPort) throws IOException {
-        return setSocketOnlyTls12(delegateFactory.createSocket(address, port, localAddress, localPort));
+        return tls12Only(delegateFactory.createSocket(address, port, localAddress, localPort));
     }
 
-    private Socket setSocketOnlyTls12(@Nullable Socket socket) {
+    @CheckForNull private Socket tls12Only(@Nullable Socket socket) {
         if (socket == null) throw new IllegalArgumentException("Socket is null.");
         if (socket instanceof SSLSocket) ((SSLSocket) socket).setEnabledProtocols(new String[]{"TLSv1.2"});
         return socket;

--- a/src/main/java/io/auklet/misc/Tls12SocketFactory.java
+++ b/src/main/java/io/auklet/misc/Tls12SocketFactory.java
@@ -14,7 +14,7 @@ import java.security.NoSuchAlgorithmException;
 
 /**
  * <p>A custom SSL socket factory that only supports TLS 1.2. This class adds compatibility for SSL connections
- * on Android versions less than 4.4W.</p>
+ * on Android versions less than 4.4W, but is safe to use in Android 4.4W+ and non-Android environments.</p>
  *
  * <p>Derived from https://gist.githubusercontent.com/fkrauthan/ac8624466a4dee4fd02f/raw/309efc30e31c96a932ab9d19bf4d73b286b00573/TLSSocketFactory.java.</p>
  *


### PR DESCRIPTION
If `Tls12SocketFactory` is instantiated with a `null` context, the default context being used was protocol `TLS`, not `TLSv1.2`. This PR fixes that discrepancy and also does minor style cleanup of the class.