### PR TITLE
Improve Auklet API credential security

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -53,6 +53,7 @@ public final class Auklet {
     private static final Logger LOGGER = LoggerFactory.getLogger(Auklet.class);
     private static final Object LOCK = new Object();
     private static final AukletDaemonExecutor DAEMON = new AukletDaemonExecutor(1, ThreadUtil.createDaemonThreadFactory("Auklet"));
+    private static final String INVALID_INIT_MSG = "Use Auklet.init() to initialize the agent.";
     @GuardedBy("LOCK") private static Auklet agent = null;
 
     private final String appId;
@@ -110,8 +111,28 @@ public final class Auklet {
         synchronized (LOCK) {
             // We check this in the init method to provide a proper message, in case the user accidentally
             // attempted to init twice. We check again here to prevent instantiation via reflection.
-            if (agent != null) throw new IllegalStateException("Use Auklet.init() to initialize the agent.");
+            if (agent != null) throw new IllegalStateException(INVALID_INIT_MSG);
         }
+
+        // We now attempt to verify who is invoking the constructor, to try to prevent instantiation.
+        // The first frame is the Util method and the next two frames are from the constructor, so we
+        // want to inspect the 4th frame.
+        //
+        // According to Oracle Javadocs, JVMs may sometimes return empty stack traces. If this happens,
+        // we have no choice but to skip this check, so warn the end user.
+        boolean verified = true;
+        StackTraceElement[] st = Util.getCurrentStackTrace();
+        if (st.length >= 4) {
+            String caller = st[3].getClassName();
+            // If it's null or empty, we have to assume the call is legitimate, so warn the end user.
+            boolean callerIsValid = !Util.isNullOrEmpty(caller);
+            if (!callerIsValid) verified = false;
+            else if (!caller.startsWith(Auklet.class.getName())) {
+                // Invalid caller, so must be external reflection.
+                throw new IllegalStateException(INVALID_INIT_MSG);
+            }
+        } else verified = false;
+        if (!verified) LOGGER.warn("Insufficient information provided by the JVM to validate Auklet constructor call. If you see this warning more than once per JVM execution, you are likely the target of a reflection attack!");
 
         LOGGER.debug("Parsing configuration.");
         if (config == null) config = new Config();
@@ -198,6 +219,17 @@ public final class Auklet {
                 throw new AukletException("Could not set default uncaught exception handler.", e);
             }
         }
+    }
+
+    /**
+     * <p>The Auklet object cannot be cloned.</p>
+     *
+     * @return nothing.
+     * @throws CloneNotSupportedException unconditionally.
+     */
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+        throw new CloneNotSupportedException();
     }
 
     /**

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -228,7 +228,7 @@ public final class Auklet {
      * @throws CloneNotSupportedException unconditionally.
      */
     @Override
-    protected Object clone() throws CloneNotSupportedException {
+    protected Object clone() throws CloneNotSupportedException { // NOSONAR
         throw new CloneNotSupportedException();
     }
 

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -335,15 +335,6 @@ public final class Auklet {
     }
 
     /**
-     * <p>Returns the API base URL for this instance of the agent.</p>
-     *
-     * @return never {@code null}.
-     */
-    @NonNull public String getBaseUrl() {
-        return this.baseUrl;
-    }
-
-    /**
      * <p>Returns the config directory for this instance of the agent.</p>
      *
      * @return never {@code null}.
@@ -416,13 +407,19 @@ public final class Auklet {
     /**
      * <p>Makes an authenticated request to the Auklet API.</p>
      *
-     * @param request never {@code null}.
+     * @param request a partially built OkHttp request object. This method fully assembles
+     * the URL component of the request and also handles authentication.
+     * @param path the URL path - that is, the entire URL minus the protocol and host/domain.
+     * Must not be {@code null} or empty.
      * @return never {@code null}.
      * @throws AukletException if an error occurs with the request.
      */
-    @NonNull public Response doApiRequest(@NonNull Request.Builder request) throws AukletException {
+    @NonNull public Response doApiRequest(@NonNull Request.Builder request, @NonNull String path) throws AukletException {
         if (request == null) throw new AukletException("HTTP request is null.");
-        request.header("Authorization", "JWT " + this.apiKey);
+        if (Util.isNullOrEmpty(path)) throw new AukletException("URL path is null or empty.");
+        request
+                .url(this.baseUrl + Util.addLeadingSlash(path))
+                .header("Authorization", "JWT " + this.apiKey);
         return this.https.doRequest(request);
     }
 

--- a/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
+++ b/src/main/java/io/auklet/config/AbstractJsonConfigFileFromApi.java
@@ -4,6 +4,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.auklet.AukletException;
 import io.auklet.util.FileUtil;
 import io.auklet.util.JsonUtil;
+import io.auklet.util.Util;
 import mjson.Json;
 import net.jcip.annotations.NotThreadSafe;
 import okhttp3.Request;
@@ -21,12 +22,16 @@ public abstract class AbstractJsonConfigFileFromApi extends AbstractConfigFileFr
      * <p>Submits a request to the Auklet API and returns the response as a JSON object.</p>
      *
      * @param request the API request. Never {@code null}.
+     * @param path the URL path - that is, the entire URL minus the protocol and host/domain.
+     * Must not be {@code null} or empty.
      * @return never {@code null}.
      * @throws AukletException if the request is {@code null}, or if the request fails or has an error.
      */
-    @NonNull protected final Json makeJsonRequest(@NonNull Request.Builder request) throws AukletException {
+    @NonNull protected final Json makeJsonRequest(@NonNull Request.Builder request, @NonNull String path) throws AukletException {
         if (request == null) throw new AukletException("JSON HTTP request is null.");
-        try (Response response = this.getAgent().doApiRequest(request)) {
+        if (Util.isNullOrEmpty(path)) throw new AukletException("JSON URL path is null or empty.");
+        request.header("Content-Type", "application/json; charset=utf-8");
+        try (Response response = this.getAgent().doApiRequest(request, path)) {
             String responseString = response.body().string();
             if (response.isSuccessful()) {
                 return JsonUtil.validateJson(JsonUtil.readJson(responseString), this.getClass().getName());

--- a/src/main/java/io/auklet/config/AukletIoBrokers.java
+++ b/src/main/java/io/auklet/config/AukletIoBrokers.java
@@ -52,10 +52,7 @@ public final class AukletIoBrokers extends AbstractJsonConfigFileFromApi {
     }
 
     @Override protected Json fetchFromApi() throws AukletException {
-        Request.Builder request = new Request.Builder()
-                .url(this.getAgent().getBaseUrl() + "/private/devices/config/").get()
-                .header("Content-Type", "application/json; charset=utf-8");
-        return this.makeJsonRequest(request);
+        return this.makeJsonRequest(new Request.Builder().get(), "/private/devices/config/");
     }
 
 }

--- a/src/main/java/io/auklet/config/AukletIoCert.java
+++ b/src/main/java/io/auklet/config/AukletIoCert.java
@@ -61,9 +61,8 @@ public final class AukletIoCert extends AbstractConfigFileFromApi<String> {
 
     @Override protected String fetchFromApi() throws AukletException {
         try {
-            Request.Builder request = new Request.Builder()
-                    .url(this.getAgent().getBaseUrl() + "/private/devices/certificates/").get();
-            try (Response response = this.getAgent().doApiRequest(request)) {
+            Request.Builder request = new Request.Builder().get();
+            try (Response response = this.getAgent().doApiRequest(request, "/private/devices/certificates/")) {
                 String responseString = response.body().string();
                 if (response.isSuccessful()) {
                     return responseString;

--- a/src/main/java/io/auklet/config/DataUsageLimit.java
+++ b/src/main/java/io/auklet/config/DataUsageLimit.java
@@ -65,11 +65,8 @@ public final class DataUsageLimit extends AbstractJsonConfigFileFromApi {
     }
 
     @Override protected Json fetchFromApi() throws AukletException {
-        String apiSuffix = String.format("/private/devices/%s/app_config/", this.getAgent().getAppId());
-        Request.Builder request = new Request.Builder()
-                .url(this.getAgent().getBaseUrl() + apiSuffix).get()
-                .header("Content-Type", "application/json; charset=utf-8");
-        return this.makeJsonRequest(request);
+        String appConfigRequest = String.format("/private/devices/%s/app_config/", this.getAgent().getAppId());
+        return this.makeJsonRequest(new Request.Builder().get(), appConfigRequest);
     }
 
     /**

--- a/src/main/java/io/auklet/config/DeviceAuth.java
+++ b/src/main/java/io/auklet/config/DeviceAuth.java
@@ -129,10 +129,8 @@ public final class DeviceAuth extends AbstractJsonConfigFileFromApi {
         requestJson.set("mac_address_hash", this.getAgent().getMacHash());
         requestJson.set("application", this.getAgent().getAppId());
         Request.Builder request = new Request.Builder()
-                .url(this.getAgent().getBaseUrl() + "/private/devices/")
-                .post(RequestBody.create(MediaType.parse("application/json; charset=utf-8"), requestJson.toString()))
-                .header("Content-Type", "application/json; charset=utf-8");
-        return this.makeJsonRequest(request);
+                .post(RequestBody.create(MediaType.parse("application/json; charset=utf-8"), requestJson.toString()));
+        return this.makeJsonRequest(request, "/private/devices/");
     }
 
     @Override protected void writeToDisk(@NonNull Json contents) throws AukletException {

--- a/src/main/java/io/auklet/net/Https.java
+++ b/src/main/java/io/auklet/net/Https.java
@@ -37,6 +37,10 @@ import java.util.List;
  * <p>Due to a technical limitation, all messages logged to {@code io.auklet.http} will always be
  * logged at level {@code INFO} (unless logging is disabled), taking into consideration the behavior
  * of the levels described above.</p>
+ *
+ * <p><b>Per the above, please note that setting the logging level for the logger {@code io.auklet.http}
+ * to any level more verbose than {@code INFO} will result in authorization headers being logged, thus
+ * leaking your Auklet API key. Do not do this in your production environment!</b></p>
  */
 @Immutable
 public final class Https {

--- a/src/main/java/io/auklet/util/Util.java
+++ b/src/main/java/io/auklet/util/Util.java
@@ -65,6 +65,18 @@ public final class Util {
     }
 
     /**
+     * <p>Adds a leading slash to the input string, unless it already has one.</p>
+     *
+     * @param s the input string.
+     * @return {@code null} if and only if the input string is {@code null}.
+     */
+    @CheckForNull public static String addLeadingSlash(@Nullable String s) {
+        if (s == null) return null;
+        if (!s.startsWith("/")) s = "/" + s;
+        return s;
+    }
+
+    /**
      * <p>Removes the trailing slash from the input string, if it has one.</p>
      *
      * @param s the input string.

--- a/src/main/java/io/auklet/util/Util.java
+++ b/src/main/java/io/auklet/util/Util.java
@@ -144,4 +144,13 @@ public final class Util {
         }
     }
 
+    /**
+     * <p>Returns the current thread's stack trace.</p>
+     *
+     * @return never {@code null}, but may be empty due to JVM vendor implementations.
+     */
+    @NonNull public static StackTraceElement[] getCurrentStackTrace() {
+        return new java.lang.Throwable().getStackTrace(); // NOSONAR
+    }
+
 }


### PR DESCRIPTION
This PR adds better handling of requests to the Auklet API by ensuring that any usage of the API key is tied exclusively to requests that only use the base URL. This ensure that API keys will only ever be sent to A. `api.auklet.io`, or B. whatever value the end user has configured for the base URL, in which case the security of their API key becomes their responsibility.