### PR TITLE
Document required permissions / allow silencing of missing permission warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ grant {
     permission java.util.PropertyPermission "java.io.tmpdir","read";
     // Most JVMs do not require these permissions. If you are sending performance data
     // to the Auklet cloud, you will need to enable loud logging of SecurityExceptions
-    // to determine if you need these permissions
+    // to determine if you need these permissions.
     permission java.util.PropertyPermission "os.name","read";
     permission java.util.PropertyPermission "os.arch","read";
     permission java.util.PropertyPermission "os.version","read";

--- a/src/main/java/io/auklet/Config.java
+++ b/src/main/java/io/auklet/Config.java
@@ -41,6 +41,17 @@ import java.util.*;
  *       <td>{@code false} (auto-start is disabled)</td>
  *     </tr>
  *     <tr>
+ *       <td>Detailed logging of SecurityExceptions</td>
+ *       <td><i>N/A</i></td>
+ *       <td>
+ *         <ol>
+ *           <li>Environment variable {@code AUKLET_LOUD_SECURITY_EXCEPTIONS}</li>
+ *           <li>JVM system property {@code auklet.loud.security.exceptions}</li>
+ *         </ol>
+ *       </td>
+ *       <td>{@code false} (SecurityExceptions will be logged normally)</td>
+ *     </tr>
+ *     <tr>
  *       <td>Application ID</td>
  *       <td>{@link #setAppId(String)}</td>
  *       <td>

--- a/src/main/java/io/auklet/config/AbstractConfigFileFromApi.java
+++ b/src/main/java/io/auklet/config/AbstractConfigFileFromApi.java
@@ -64,12 +64,8 @@ public abstract class AbstractConfigFileFromApi<T> extends AbstractConfigFile {
      * @throws IOException if the file cannot be read.
      */
     @NonNull protected final String getStringFromDisk() throws IOException {
-        try {
-            byte[] bytes = FileUtil.read(this.file);
-            return new String(bytes, "UTF-8");
-        } catch (SecurityException e) {
-            throw new IOException(e);
-        }
+        byte[] bytes = FileUtil.read(this.file);
+        return new String(bytes, "UTF-8");
     }
 
 }

--- a/src/main/java/io/auklet/config/DataUsageTracker.java
+++ b/src/main/java/io/auklet/config/DataUsageTracker.java
@@ -43,7 +43,7 @@ public final class DataUsageTracker extends AbstractConfigFile {
             // Parse the JSON and set relevant fields.
             Json usageJson = JsonUtil.validateJson(JsonUtil.readJson(usageString), this.getClass().getName());
             this.bytesSent = usageJson.at(USAGE_KEY, 0L).asLong();
-        } catch (IOException | SecurityException | IllegalArgumentException e) {
+        } catch (IOException | IllegalArgumentException e) {
             LOGGER.warn("Could not read data usage tracker file from disk, assuming zero usage.", e);
         }
     }
@@ -101,7 +101,10 @@ public final class DataUsageTracker extends AbstractConfigFile {
                     }
                     try {
                         writeUsageToDisk(givenUsage);
-                    } catch (IOException | SecurityException e) {
+                    } catch (SecurityException e) {
+                        if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Could not save data usage to disk.", e);
+                        else LOGGER.warn("Could not save data usage to disk: " + e.getMessage());
+                    } catch (IOException e) {
                         LOGGER.warn("Could not save data usage to disk.", e);
                     }
                 }

--- a/src/main/java/io/auklet/config/DeviceAuth.java
+++ b/src/main/java/io/auklet/config/DeviceAuth.java
@@ -118,7 +118,7 @@ public final class DeviceAuth extends AbstractJsonConfigFileFromApi {
             String authFileDecrypted = new String(this.aesCipher.doFinal(authFileBytes));
             // Parse the JSON and set relevant fields.
             return JsonUtil.validateJson(JsonUtil.readJson(authFileDecrypted), this.getClass().getName());
-        } catch (AukletException | IOException | SecurityException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException | IllegalArgumentException e) {
+        } catch (AukletException | IOException | InvalidKeyException | IllegalBlockSizeException | BadPaddingException | IllegalArgumentException e) {
             LOGGER.warn("Could not read device auth file from disk, will re-register device with API.", e);
             return null;
         }

--- a/src/main/java/io/auklet/misc/OSMX.java
+++ b/src/main/java/io/auklet/misc/OSMX.java
@@ -75,7 +75,7 @@ public enum OSMX {
         try {
             return get().getName();
         } catch (SecurityException e) {
-            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS name", e);
+            if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS name", e);
             return "";
         }
     }
@@ -84,7 +84,7 @@ public enum OSMX {
         try {
             return get().getArch();
         } catch (SecurityException e) {
-            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS arch", e);
+            if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS arch", e);
             return "";
         }
     }
@@ -93,7 +93,7 @@ public enum OSMX {
         try {
             return get().getVersion();
         } catch (SecurityException e) {
-            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS version", e);
+            if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS version", e);
             return "";
         }
     }

--- a/src/main/java/io/auklet/misc/OSMX.java
+++ b/src/main/java/io/auklet/misc/OSMX.java
@@ -1,6 +1,7 @@
 package io.auklet.misc;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import io.auklet.Auklet;
 import net.jcip.annotations.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,7 @@ public enum OSMX {
         try {
             return get().getName();
         } catch (SecurityException e) {
-            LOGGER.warn("Cannot get OS name", e);
+            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS name", e);
             return "";
         }
     }
@@ -83,7 +84,7 @@ public enum OSMX {
         try {
             return get().getArch();
         } catch (SecurityException e) {
-            LOGGER.warn("Cannot get OS arch", e);
+            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS arch", e);
             return "";
         }
     }
@@ -92,7 +93,7 @@ public enum OSMX {
         try {
             return get().getVersion();
         } catch (SecurityException e) {
-            LOGGER.warn("Cannot get OS version", e);
+            if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Cannot get OS version", e);
             return "";
         }
     }

--- a/src/main/java/io/auklet/platform/AbstractPlatform.java
+++ b/src/main/java/io/auklet/platform/AbstractPlatform.java
@@ -20,6 +20,7 @@ import java.util.List;
 public abstract class AbstractPlatform extends HasAgent implements Platform {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlatform.class);
+    private static final String DIR_ERROR = "Skipping directory '{}' due to an error.";
 
     @Override public void start(@NonNull Auklet agent) throws AukletException {
         this.setAgent(agent);
@@ -38,7 +39,7 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
                     return new File(dir);
                 }
             } catch (SecurityException e) {
-                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
                 else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
             }
         }
@@ -49,10 +50,10 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
             try {
                 return tryDir(new File(dir));
             } catch (SecurityException e) {
-                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
                 else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
             } catch (IllegalArgumentException | UnsupportedOperationException | IOException e) {
-                LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                LOGGER.warn(DIR_ERROR, dir, e);
             }
         }
         return null;

--- a/src/main/java/io/auklet/platform/AbstractPlatform.java
+++ b/src/main/java/io/auklet/platform/AbstractPlatform.java
@@ -38,7 +38,8 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
                     return new File(dir);
                 }
             } catch (SecurityException e) {
-                LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
             }
         }
 
@@ -47,7 +48,10 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
         for (String dir : configDirs) {
             try {
                 return tryDir(new File(dir));
-            } catch (IllegalArgumentException | UnsupportedOperationException | IOException | SecurityException e) {
+            } catch (SecurityException e) {
+                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
+                else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
+            } catch (IllegalArgumentException | UnsupportedOperationException | IOException e) {
                 LOGGER.warn("Skipping directory '{}' due to an error.", dir, e);
             }
         }

--- a/src/main/java/io/auklet/platform/AbstractPlatform.java
+++ b/src/main/java/io/auklet/platform/AbstractPlatform.java
@@ -65,7 +65,7 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
                     return new File(dir);
                 }
             } catch (SecurityException e) {
-                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
+                if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
                 else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
             }
         }
@@ -88,7 +88,7 @@ public abstract class AbstractPlatform extends HasAgent implements Platform {
                 File dirFile = new File(dir);
                 if (dirWriteTest(dirFile)) return dirFile;
             } catch (SecurityException e) {
-                if ( Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
+                if (Auklet.LOUD_SECURITY_EXCEPTIONS) LOGGER.warn(DIR_ERROR, dir, e);
                 else LOGGER.warn("Skipping directory '{}' due to an error: {}", dir, e.getMessage());
             } catch (IllegalArgumentException | UnsupportedOperationException | IOException e) {
                 LOGGER.warn(DIR_ERROR, dir, e);

--- a/src/main/java/io/auklet/platform/JavaPlatform.java
+++ b/src/main/java/io/auklet/platform/JavaPlatform.java
@@ -2,7 +2,9 @@ package io.auklet.platform;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import io.auklet.Auklet;
 import io.auklet.AukletException;
+import io.auklet.util.SysUtil;
 import io.auklet.util.Util;
 import io.auklet.misc.OSMX;
 import net.jcip.annotations.Immutable;
@@ -27,9 +29,9 @@ public final class JavaPlatform extends AbstractPlatform {
         // Consider config dir settings in this order.
         List<String> possibleConfigDirs = Arrays.asList(
                 fromConfig,
-                System.getProperty("user.dir"),
-                System.getProperty("user.home"),
-                System.getProperty("java.io.tmpdir")
+                SysUtil.getSysProp("user.dir", Auklet.LOUD_SECURITY_EXCEPTIONS),
+                SysUtil.getSysProp("user.home", Auklet.LOUD_SECURITY_EXCEPTIONS),
+                SysUtil.getSysProp("java.io.tmpdir", Auklet.LOUD_SECURITY_EXCEPTIONS)
         );
 
         // Drop any env vars/sysprops whose value is null, and append the auklet subdir to each remaining value.

--- a/src/main/java/io/auklet/util/FileUtil.java
+++ b/src/main/java/io/auklet/util/FileUtil.java
@@ -74,6 +74,8 @@ public final class FileUtil {
         byte[] bytes = new byte[(int) file.length()];
         try (DataInputStream stream = new DataInputStream(new BufferedInputStream(new FileInputStream(file)))) {
             stream.readFully(bytes);
+        } catch (SecurityException e) {
+            throw new IOException(e);
         }
         return bytes;
     }

--- a/src/main/java/io/auklet/util/SysUtil.java
+++ b/src/main/java/io/auklet/util/SysUtil.java
@@ -23,24 +23,15 @@ public final class SysUtil {
      * empty, or refers to an environment variable that is not set, and the JVM system property named
      * by this parameter is set, this function returns the value of that JVM system property. If this
      * parameter is {@code null} or empty, no JVM system property is checked.
+     * @param warnOnException if the JVM security manager forbids retrieval of an environment variable
+     * or JVM system property, the resulting {@link SecurityException} will be logged, but only if
+     * this parameter is {@code true}; otherwise, the exception will be silenced.
      * @return possibly {@code null}.
      */
     @CheckForNull
-    public static String getValue(@Nullable String fromThisObj, @Nullable String envVar, @Nullable String sysProp) {
+    public static String getValue(@Nullable String fromThisObj, @Nullable String envVar, @Nullable String sysProp, boolean warnOnException) {
         if (fromThisObj != null) return fromThisObj;
-        String fromEnv = null;
-        try {
-            if (!Util.isNullOrEmpty(envVar)) fromEnv = System.getenv(envVar);
-        } catch (SecurityException e) {
-            LOGGER.warn("Could not get env var '{}'.", envVar, e);
-        }
-        String fromProp = null;
-        try {
-            if (!Util.isNullOrEmpty(sysProp)) fromProp = System.getProperty(sysProp);
-        } catch (SecurityException e) {
-            LOGGER.warn("Could not get JVM sys prop '{}'.", sysProp, e);
-        }
-        return Util.orElse(fromEnv, fromProp);
+        return Util.orElse(getEnvVar(envVar, warnOnException), getSysProp(sysProp, warnOnException));
     }
 
     /**
@@ -54,12 +45,16 @@ public final class SysUtil {
      * empty, or refers to an environment variable that is not set, and the JVM system property named
      * by this parameter is set, this function returns the value of that JVM system property. If this
      * parameter is {@code null} or empty, no JVM system property is checked.
+     * @param warnOnException if the JVM security manager forbids retrieval of an environment variable
+     * or JVM system property, the resulting {@link SecurityException} will be logged, but only if
+     * this parameter is {@code true}; otherwise, the exception will be silenced.
      * @return whatever boolean value is determined by the logic described above, or {@code null}
      * if all above described options fail to produce a value.
      */
-    @CheckForNull public static Boolean getValue(@Nullable Boolean fromThisObj, @Nullable String envVar, @Nullable String sysProp) {
+    @CheckForNull
+    public static Boolean getValue(@Nullable Boolean fromThisObj, @Nullable String envVar, @Nullable String sysProp, boolean warnOnException) {
         if (fromThisObj != null) return fromThisObj;
-        String stringValue = getValue((String) null, envVar, sysProp);
+        String stringValue = getValue((String) null, envVar, sysProp, warnOnException);
         return stringValue == null ? null : Boolean.valueOf(stringValue);
     }
 
@@ -74,18 +69,62 @@ public final class SysUtil {
      * empty, or refers to an environment variable that is not set, and the JVM system property named
      * by this parameter is set, this function returns the value of that JVM system property. If this
      * parameter is {@code null} or empty, no JVM system property is checked.
+     * @param warnOnException if the JVM security manager forbids retrieval of an environment variable
+     * or JVM system property, the resulting {@link SecurityException} will be logged, but only if
+     * this parameter is {@code true}; otherwise, the exception will be silenced.
      * @return whatever boolean value is determined by the logic described above, or {@code null}
      * if all above described options fail to produce a value.
      */
-    @CheckForNull public static Integer getValue(@Nullable Integer fromThisObj, @Nullable String envVar, @Nullable String sysProp) {
+    @CheckForNull
+    public static Integer getValue(@Nullable Integer fromThisObj, @Nullable String envVar, @Nullable String sysProp, boolean warnOnException) {
         if (fromThisObj != null) return fromThisObj;
-        String stringValue = getValue((String) null, envVar, sysProp);
+        String stringValue = getValue((String) null, envVar, sysProp, warnOnException);
         if (stringValue == null) return null;
         try {
             return Integer.valueOf(stringValue);
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    /**
+     * <p>Returns a JVM environment variable.</p>
+     *
+     * @param envVar the JVM environment variable to retrieve.
+     * @param warnOnException if the JVM security manager forbids retrieval of the specified JVM environment
+     * variable, the resulting {@link SecurityException} will be logged, but only if this parameter is
+     * {@code true}; otherwise, the exception will be silenced.
+     * @return {@code null} if the first argument is {@code null} or empty, or if the specified env var
+     * is not defined, or if the JVM security manager forbids access to the specified env var.
+     */
+    @CheckForNull
+    public static String getEnvVar(@Nullable String envVar, boolean warnOnException) {
+        try {
+            if (!Util.isNullOrEmpty(envVar)) return System.getenv(envVar);
+        } catch (SecurityException e) {
+            if (warnOnException) LOGGER.warn("Could not get env var '{}'.", envVar, e);
+        }
+        return null;
+    }
+
+    /**
+     * <p>Returns a JVM system property.</p>
+     *
+     * @param sysProp the JVM system property to retrieve.
+     * @param warnOnException if the JVM security manager forbids retrieval of the specified JVM system
+     * property, the resulting {@link SecurityException} will be logged, but only if this parameter is
+     * {@code true}; otherwise, the exception will be silenced.
+     * @return {@code null} if the first argument is {@code null} or empty, or if the specified property
+     * is not defined, or if the JVM security manager forbids access to the specified property.
+     */
+    @CheckForNull
+    public static String getSysProp(@Nullable String sysProp, boolean warnOnException) {
+        try {
+            if (!Util.isNullOrEmpty(sysProp)) return System.getProperty(sysProp);
+        } catch (SecurityException e) {
+            if (warnOnException) LOGGER.warn("Could not get JVM sys prop '{}'.", sysProp, e);
+        }
+        return null;
     }
 
 }

--- a/src/main/java/io/auklet/util/ThreadUtil.java
+++ b/src/main/java/io/auklet/util/ThreadUtil.java
@@ -58,8 +58,8 @@ public final class ThreadUtil {
             LOGGER.warn("Interrupted while awaiting ExecutorService shutdown.", ie);
             es.shutdownNow();
             Thread.currentThread().interrupt();
-        } catch (SecurityException se) {
-            LOGGER.warn("Could not shut down ExecutorService.", se);
+        } catch (SecurityException e) {
+            LOGGER.warn("Could not shut down ExecutorService.", e);
         }
     }
 


### PR DESCRIPTION
This PR documents the permissions that the Auklet agent (and its dependencies) require in order to function, along with additional optional/recommended permissions depending on what features the end user may be using.

To ensure that logging is kept to a minimum, and also because end users could forego envvar/sysprop configuration entirely and thus do not need to see these warnings, logging of warnings when Auklet config envvars/sysprops are forbidden by the JVM security manager are suppressed by default, and can be re-enabled by the envvar/sysprop `AUKLET_LOUD_SECURITY_EXCEPTIONS/auklet.loud.security.exceptions`, which themselves require their own permissions (and thus are documented in this PR).