### PR TITLE
Minor bug fixes

### DIFF
--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -598,8 +598,7 @@ public final class Auklet {
      */
     private void doShutdown(boolean viaJvmHook) {
         LOGGER.info("Shutting down agent.");
-        boolean jvmHookIsShuttingDown = this.shutdownHook != null && viaJvmHook;
-        if (!jvmHookIsShuttingDown) Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
+        if (!viaJvmHook && this.shutdownHook != null) Runtime.getRuntime().removeShutdownHook(this.shutdownHook);
         this.sink.shutdown();
         this.https.shutdown();
     }

--- a/src/main/java/io/auklet/Auklet.java
+++ b/src/main/java/io/auklet/Auklet.java
@@ -110,7 +110,7 @@ public final class Auklet {
         LOUD_SECURITY_EXCEPTIONS = Boolean.valueOf(fromEnv) || Boolean.valueOf(fromProp);
         if (LOUD_SECURITY_EXCEPTIONS) {
             LOGGER.info("SecurityException loud logging is enabled.");
-        } else if (blockedEnv || blockedProp) {
+        } else if (blockedEnv && blockedProp) {
             // We only log the error if the end result is not true. This implies that exactly
             // one of the two calls resulted in a SecurityException and that the other call
             // was successful and returned true, so there would be no reason to log anything.


### PR DESCRIPTION
1. If loud logging of security exceptions was disabled, a warning would be logged if _either_ the JVM sysprop _or_ the envvar that controls this feature could not be checked. This is a bug; now, the warning is logged only if _both_ the JVM sysprop _and_ the envvar could not be checked.
2. A subtle bug regarding explicit shutdown and JVM shutdown hooks was fixed:
	- In policy-controlled JVM environments, it is possible that the `java.lang.RuntimePermission "shutdownHooks"` is not granted. In such scenarios, if the agent is configured to install a JVM shutdown hook, an exception will occur *on startup* and the agent will fail to initialize. This is intended behavior.
	- When the agent is shut down, the agent currently attempts to remove its JVM shutdown hook if either of the following is true: A. the shutdown hook is `null`, or B. the shutdown is explicit via `Auklet.shutdown()`. **This logic is the bug fixed in this PR.**
	- In a non-policy-controlled environment, this bug is silent and causes no issue, because removing a `null` JVM shutdown hook silently succeeds. However, in a policy-controlled environment, this bug causes a confusing `SecurityException` when the aforementioned permission is not granted.
	- Shutdown hook removal is now only attempted if A. the shutdown hook is not `null`, _AND_ B. the shutdown is explicit via `Auklet.shutdown()`.